### PR TITLE
fixed aodpre.ComputeTraces missing insert

### DIFF
--- a/matlab/schemas/+aodpre/ComputeTraces.m
+++ b/matlab/schemas/+aodpre/ComputeTraces.m
@@ -33,6 +33,7 @@ classdef ComputeTraces < dj.Relvar & dj.AutoPopulate
                     for i=1:length(keys)
                         tuple = keys(i);
                         tuple.trace = single(X(:,i));
+                        insert(aodpre.Trace,tuple);
                     end
                     
                 otherwise


### PR DESCRIPTION
Previously computed but did not insert tuples with preprocess_id=1
