### PR TITLE
Add slice alignment against structural stack

### DIFF
--- a/matlab/schemas/+pre/SliceAlignment.m
+++ b/matlab/schemas/+pre/SliceAlignment.m
@@ -1,0 +1,135 @@
+%{
+pre.SliceAlignment (imported) # my newest table
+-> pre.AverageFrame
+-> rf.Stack
+-----
+score:   float      # cross correlation score
+depth:   float      # depth in the stack in microns
+x_shift: float      # shift in x direction in microns
+y_shift: float      # shift in y direction in microns
+%}
+
+classdef SliceAlignment < dj.Relvar & dj.AutoPopulate
+
+	properties
+		popRel = pro(rf.Scan) * pro(rf.Stack) * pre.Channel & pre.AverageFrame;
+	end
+
+	methods(Access=protected)
+		function makeTuples(self, key)
+            startTime = tic;
+            
+            scanInfo = fetch(pre.ScanInfo & key, '*');
+            
+            stack = fetch(rf.Stack & key, '*');
+            basePath = fetch1(rf.Session & key, 'scan_path');
+            basePath = getLocalPath(basePath);
+            fileBase = fetch1(rf.Session & key, 'file_base');
+            stackPath = fullfile(basePath, sprintf('%sstack_%05d_*.tif', fileBase, stack.stack_idx));
+            
+            fprintf('Loading structural stack...'); tic;
+            stackData = ne7.scanimage.Reader4(stackPath);
+            fprintf('(completed in %.2f seconds)\n',toc);
+            
+            % will work only if the zoom level is the same for the scans
+            % and the stack
+            assert(abs(stackData.zoom - scanInfo.zoom) < eps(scanInfo.zoom));
+            scanSize = [scanInfo.px_height scanInfo.px_width];
+            stackSize = size(stackData);
+            
+            targetSize = max([scanSize; stackSize(1:2)]);
+            pxPitch = [scanInfo.um_height, scanInfo.um_height] ./ targetSize;
+            
+            fprintf('Normalizing structural stack...'); tic;
+            avgStack = squeeze(mean(stackData(:, :, key.channel, :, :), 5));
+            normStack = normalizeImages(avgStack, targetSize);
+            fprintf('(completed in %.2f seconds)\n',toc);
+            
+            
+            % now align each frame, one at a time
+            avgFrameKeys = fetch(pre.AverageFrame & key);
+            for idxFrame = 1:length(avgFrameKeys)
+                fprintf('Aligning slice %d...', idxFrame); tic;
+                tuple = avgFrameKeys(idxFrame);
+                
+                % normalize the frame
+                avgFrame = fetch1(pre.AverageFrame & tuple, 'frame');
+                normFrame = normalizeImages(avgFrame, targetSize);
+                
+                % cross correlation to find best maching indicies
+                sliceLoc = findImageInStack(normFrame, normStack);
+                
+                % convert pixcels and slice number into microns
+                tuple.stack_idx = key.stack_idx;
+                tuple.score = sliceLoc.score;
+                tuple.depth = (sliceLoc.depth - 1) * stackData.slice_pitch;
+                tuple.y_shift = sliceLoc.shift(1) * pxPitch(1);
+                tuple.x_shift = sliceLoc.shift(2) * pxPitch(2);
+                
+                self.insert(tuple);
+                fprintf('(completed in %.2f seconds)\n',toc);
+            end
+            
+            fprintf('Overall ompleted in %.2f seconds\n',toc(startTime));
+        end
+    end
+end
+
+function imgLoc = findImageInStack(img, stack)
+% Given a stack of images and an image,
+% finds the best matching x,y shift and the depth
+% within the stack
+    maxScore = 0;
+    maxDepth = 1;
+    maxPos = 0;
+    for idxDepth = 1:size(stack, 3)
+        template = stack(:,:,idxDepth);
+
+        % compute cross correlation via Fourier domains
+        xcorr = ifft2(fft2(img) .* conj(fft2(template)));
+        [score, pos] = max(xcorr(:));
+        if score > maxScore
+            maxScore = score;
+            maxDepth = idxDepth;
+            maxPos = pos;
+        end
+    end
+    sz = size(img);
+    [y, x] = ind2sub(sz, maxPos);
+    yh = sz(1)/2; y = mod(y+yh, sz(1)) - yh;
+    xh = sz(2)/2; x = mod(x+xh, sz(2)) - xh;
+
+    % record the result
+    imgLoc.score = maxScore;
+    imgLoc.depth = maxDepth;
+    imgLoc.shift = [y, x];
+end
+
+function normalizedImages = normalizeImages(images, targetSize)
+% Normalize each image such that the mean is 0 and L2 norm of the
+% image is 1 (same thing as variance of 1). If images is 3D, assumes that
+% the 3rd index is the image number and applies normalization on each
+% image separately.
+    sz = size(images);
+    if nargin < 2
+        targetSize = sz(1:2);
+    end
+    resize = any(targetSize ~= sz(1:2));
+    
+    if ndims(images) == 2
+        N = 1;
+    else
+        N = size(images, 3);
+    end
+       
+    normalizedImages = zeros([targetSize, N]);
+    for idx = 1:N
+        img = images(:, :, idx);
+        if resize
+            img = imresize(img, targetSize);
+        end
+        img = img - mean(img(:));
+        normalizedImages(:, :, idx) = img ./ norm(img(:));
+    end
+    normalizedImages = squeeze(normalizedImages);
+end


### PR DESCRIPTION
- Added slice alignment. Uses simple cross correlation to determine the closest matching slice in the structural stack for each slice in the functional scan.
- Also gives you the offset within the matching slice. 
- Currently works only if the structural stack and functional scans are acquired under same zoom and thus FOV.
