### PR TITLE
Include atlab/commons as part of the Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,11 @@ RUN \
 RUN \
   pip install git+https://github.com/cajal/c2s.git
 
+# Install commons
+RUN \
+  git clone https://github.com/atlab/commons.git && \
+  pip install -e commons/python/
+
 
 # Install pipeline
 COPY . /data/pipeline


### PR DESCRIPTION
Update pipeline Docker image to install `commons` schema from https://github.com/atlab/commons.git
