### PR TITLE
population of Spikes and ComputeTraces works correctly in MATLAB

### DIFF
--- a/matlab/schemas/+preprocess/ComputeTraces.m
+++ b/matlab/schemas/+preprocess/ComputeTraces.m
@@ -8,13 +8,19 @@ preprocess.ComputeTraces (computed) # compute traces
 classdef ComputeTraces < dj.Relvar & dj.AutoPopulate
 
 	properties
-		popRel = preprocess.ExtractRaw  % !!! update the populate relation
+        % Twitch traces are populated in Python
+		popRel = preprocess.ExtractRaw & (experiment.SessionFluorophore & 'fluorophore!="Twitch2B"'); 
 	end
 
 	methods(Access=protected)
 
 		function makeTuples(self, key)
-            error('Implemented in python.')
+            % Copy traces from ExtractRawTrace
+            tuples = fetch(preprocess.ExtractRawTrace & key,'raw_trace->trace','*');
+            tuples = rmfield(tuples,'channel');
+            
+            self.insert(key)
+            insert(preprocess.ComputeTracesTrace,tuples);
 		end
 	end
 

--- a/matlab/schemas/+preprocess/Spikes.m
+++ b/matlab/schemas/+preprocess/Spikes.m
@@ -9,14 +9,23 @@ preprocess.Spikes (computed) # infer spikes from calcium traces
 classdef Spikes < dj.Relvar & dj.AutoPopulate
 
 	properties
-		popRel = preprocess.ComputeTraces*preprocess.SpikeMethod  % !!! update the populate relation
+        % NMF spikes (method 5) can be copied via MATLAB, STM spike detection is performed in Python
+		popRel = preprocess.ComputeTraces*preprocess.SpikeMethod  & preprocess.ExtractRawSpikeRate & 'spike_method=5';
 	end
 
 	methods(Access=protected)
 
 		function makeTuples(self, key)
-		%!!! compute missing fields for key here
+            
+            % Copy NMF spikes from preprocess.ExtractRawSpikeRate
+            tuples = fetch(preprocess.ExtractRawSpikeRate & key,'spike_trace->rate_trace','*');
+            tuples = rmfield(tuples,'channel');
+            [tuples.spike_method] = deal(5);
+            
 			self.insert(key)
+            insert(preprocess.SpikesRateTrace,tuples);
+            
+            
 		end
 	end
 


### PR DESCRIPTION
Implemented copying of NMF spikes and copying of non-Twitch traces in MATLAB preprocess.Spikes and preprocess.ComputeTraces respectively.