### PR TITLE
bugfix in PrepareGalvo

### DIFF
--- a/matlab/schemas/+preprocess/PrepareGalvo.m
+++ b/matlab/schemas/+preprocess/PrepareGalvo.m
@@ -51,8 +51,8 @@ classdef PrepareGalvo < dj.Relvar
             [~, i] = min(abs(log(mags/zoom)));
             mag = mags(i); % closest measured magnification
             [key.um_width, key.um_height] = fetch1(fov & struct('mag', mag), 'width', 'height');
-            key.um_width = key.um_width * zoom/mag;
-            key.um_height = key.um_height * zoom/mag;
+            key.um_width = key.um_width * mag/zoom;
+            key.um_height = key.um_height * mag/zoom;
             
             key.slice_pitch = reader.slice_pitch;
             key.fps = reader.fps;


### PR DESCRIPTION
- ratio was the wrong way around. If zoom=1 and the closest zoom is 1.1, then the scaling for the FOV should be 1.1/1 not 1/1.1. 