### PR TITLE
pupil tracker update and import cleanup

### DIFF
--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -1,6 +1,5 @@
 import datajoint as dj
-from tiffreader import TIFFReader
-from . import experiment, vis, PipelineException
+from . import experiment, PipelineException
 
 from warnings import warn
 import numpy as np

--- a/python/pipeline/utils/eye_tracking.py
+++ b/python/pipeline/utils/eye_tracking.py
@@ -420,7 +420,8 @@ class PupilTracker:
             ellipse, eye_center, contour = None, None, None
             _, contours, hierarchy1 = cv2.findContours(thres, cv2.RETR_TREE, cv2.CHAIN_APPROX_SIMPLE)
             contour, ellipse = self.get_pupil_from_contours(contours, small_gray)
-            self.display(gray, blur, thres, eye_roi, fr_count, n_frames, ncontours=len(contours))
+            if display:
+                self.display(gray, blur, thres, eye_roi, fr_count, n_frames, ncontours=len(contours))
 
 
             if contour is None:


### PR DESCRIPTION
- fix one bug that didn't allow the eyetracking to be run in a docker container 
- cleanup imports so tiffreader and caiman do not *need* to be installed unless you need them