### PR TITLE
Fix bug of using zstepsize when calculating slice's depth

### DIFF
--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -80,14 +80,14 @@ class ScanInfo(dj.Imported):
 
             # Get attributes
             x_zero, y_zero, _ = scan.motor_position_at_zero # motor x, y at ScanImage's 0
-            z_zero = (experiment.Scan() & key).fetch1['depth'] # true z at ScanImage's 0
+            z_zero = (experiment.Scan() & key).fetch1('depth') # true z at ScanImage's 0
             tuple_['px_height'] = scan.field_heights[field_id]
             tuple_['px_width'] = scan.field_widths[field_id]
             tuple_['um_height'] = scan.field_heights_in_microns[field_id]
             tuple_['um_width'] = scan.field_widths_in_microns[field_id]
             tuple_['x'] = x_zero + scan._degrees_to_microns(scan.fields[field_id].x)
             tuple_['y'] = y_zero + scan._degrees_to_microns(scan.fields[field_id].y)
-            tuple_['z'] = z_zero + scan.field_depths[field_id] * scan.zstep_in_microns
+            tuple_['z'] = z_zero + scan.field_depths[field_id]
             tuple_['delay_image'] = scan.field_offsets[field_id]
             tuple_['roi'] = scan.field_rois[field_id][0]
 

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -10,6 +10,7 @@ from . import experiment, notify, shared
 from .utils import galvo_corrections, signal, quality, mask_classification
 from .exceptions import PipelineException
 
+
 schema = dj.schema('pipeline_reso', locals())
 CURRENT_VERSION = 1
 
@@ -157,11 +158,9 @@ class ScanInfo(dj.Imported):
         self.insert1(tuple_)
 
         # Insert slice information
-        slice_depths = [z * scan.zstep_in_microns for z in scan.field_depths]
-        depth_zero = (experiment.Scan() & key).fetch1('depth')  # true z at ScanImage's 0
-        for slice_id, slice_depth in enumerate(slice_depths):
-            ScanInfo.Slice().insert1({**key, 'slice': slice_id + 1, 'z': (depth_zero +
-                                                                          slice_depth)})
+        z_zero = (experiment.Scan() & key).fetch1('depth')  # true depth at ScanImage's 0
+        for slice_id, z_slice in enumerate(scan.field_depths):
+            ScanInfo.Slice().insert1({**key, 'slice': slice_id + 1, 'z': z_zero + z_slice})
 
         # Compute quantal size for all slice/channel combinations
         for slice_id in range(scan.num_fields):


### PR DESCRIPTION
Processed scans have already been fixed, but use this version to process new things (otherwise zs may be wrong)