### PR TITLE
Split Dockerfile, add fabfile, rename summary image attributes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,107 +1,8 @@
 #FROM datajoint/datajoint:latest
 FROM eywalker/tensorflow-jupyter:v1.0.1-cuda8.0-cudnn5
-MAINTAINER Edgar Y. Walker, Fabian Sinz
+LABEL maintainer="Edgar Y. Walker, Fabian Sinz, Erick Cobos"
 
 WORKDIR /data
-
-# install tools to compile
-RUN \
-  apt-get update && \
-  apt-get install -y -q \
-    build-essential && \
-  apt-get update && \
-  apt-get install  --fix-missing -y -q \
-    autoconf \
-    automake \
-    libtool \
-    octave \
-    wget \
-    bzip2 \
-    git
-
-RUN apt-get install -y build-essential cmake pkg-config libjpeg8-dev libtiff5-dev libjasper-dev \
-    libpng12-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev \
-    libgtk-3-dev libatlas-base-dev ffmpeg locate libhdf5-dev && updatedb
-
-
-# because opencv 3.1.0 is currently not cuda8.0 compatible, we use an
-# alternative versiion 
-#RUN git clone https://github.com/Itseez/opencv.git && \
-#    cd opencv && git checkout 3.1.0 && \
-RUN git clone https://github.com/daveselinger/opencv && \
-    cd opencv && git checkout 3.1.0-with-cuda8 && \ 
-    cd .. && git clone https://github.com/Itseez/opencv_contrib.git && \
-    cd opencv_contrib && git checkout 3.1.0 && \
-    cd ../opencv && mkdir build && cd build && \
-    cmake -D CMAKE_BUILD_TYPE=RELEASE  \
-    	  -D WITH_CUDA=ON         \
-	  -D CMAKE_INSTALL_PREFIX=/usr/local \
-	  -D OPENCV_EXTRA_MODULES_PATH=/data/opencv_contrib/modules  \
-	  -D CUDA_CUDA_LIBRARY=`locate libcuda.so`  \
-	  -D BUILD_EXAMPLES=ON ..  && \
-    make -j12 && \
-    make install && \
-    ldconfig && \
-    rm -rf /data/opencv /data/opencv_contrib && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
-    apt-get clean
-
-
-# install datajoint
-RUN pip3 install git+https://github.com/datajoint/datajoint-python.git
-
-
-# --- install HDF5 reader and nose
-RUN pip3 install h5py nose
-
-
-## --- install Spike Triggered Mixture Model for deconvolution
-RUN git clone https://github.com/lucastheis/cmt.git && \
-  cd ./cmt/code/liblbfgs && \
-  ./autogen.sh && \
-  ./configure --enable-sse2 && \
-  make CFLAGS="-fPIC" && \
-  cd ../..  && \
-  python3 setup.py build && \
-  python3 setup.py install
-
-
-RUN pip3 install git+https://github.com/cajal/c2s.git
-
-
-# Instal FFTW (C library) and pyfftw (its python wrapper)
-RUN wget http://www.fftw.org/fftw-3.3.6-pl2.tar.gz && \
-    tar -xvzf fftw-3.3.6-pl2.tar.gz && \
-    cd fftw-3.3.6-pl2 && \
-    ./configure --enable-threads --with-pic --enable-float --enable-sse --enable-sse2 --enable-avx && \
-    make && make install && \
-    ./configure --enable-threads --with-pic --enable-sse2 -enable-avx && \
-    make && make install && \
-    ./configure --enable-threads --with-pic --enable-long-double && \
-    make && make install && \
-    cd .. && rm fftw-3.3.6-pl2.tar.gz && \
-    pip3 install pyfftw
-
-
-# --- install CaImAn
-RUN apt-get update -y -q && \
-    apt-get install -y software-properties-common && \
-    wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \
-    apt-get update -y -q && \
-    apt-get install -y clang-3.9 lldb-3.9 && \
-    apt-get install -y libc6-i386  libsuitesparse-dev && \
-    export LLVM_CONFIG=/usr/lib/llvm-3.9/bin/llvm-config && \ 
-    git clone --recursive https://github.com/ecobost/CaImAn.git && \
-    pip3 install cython scikit-image ipyparallel psutil numba && \
-    pip3 install -r CaImAn/requirements_pip.txt && \
-    pip3 install git+https://github.com/j-friedrich/OASIS.git && \
-    pip3 install future cvxpy
-
-RUN grep -vwE "install_requires=" CaImAn/setup.py > tmp && mv tmp CaImAn/setup.py &&\
-    pip3 install -e CaImAn/
-
-
 # --- install scanreader
 RUN \
   git clone https://github.com/atlab/scanreader.git && \
@@ -113,10 +14,7 @@ RUN \
   pip3 install -e pipeline/python/
 
 RUN git clone https://github.com/atlab/commons.git && \
-    pip3 install -e commons/python && \
-    pip3 install scikit-learn --upgrade && \
-    pip3 install imreg_dft
+    pip3 install -e commons/python
 
-RUN pip3 install slacker
 
 ENTRYPOINT ["worker"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 #FROM datajoint/datajoint:latest
-FROM eywalker/tensorflow-jupyter:v1.0.1-cuda8.0-cudnn5
+FROM ninai/pipeline:base
 LABEL maintainer="Edgar Y. Walker, Fabian Sinz, Erick Cobos"
 
 WORKDIR /data
+
 # --- install scanreader
 RUN \
   git clone https://github.com/atlab/scanreader.git && \
@@ -15,6 +16,5 @@ RUN \
 
 RUN git clone https://github.com/atlab/commons.git && \
     pip3 install -e commons/python
-
 
 ENTRYPOINT ["worker"]

--- a/Dockerfiles/Dockerfile.base
+++ b/Dockerfiles/Dockerfile.base
@@ -1,0 +1,110 @@
+#FROM datajoint/datajoint:latest
+FROM eywalker/tensorflow-jupyter:v1.0.1-cuda8.0-cudnn5
+LABEL maintainer="Edgar Y. Walker, Fabian Sinz, Erick Cobos"
+
+WORKDIR /data
+
+# install tools to compile
+RUN \
+  apt-get update && \
+  apt-get install -y -q \
+    build-essential && \
+  apt-get update && \
+  apt-get install  --fix-missing -y -q \
+    autoconf \
+    automake \
+    libtool \
+    octave \
+    wget \
+    bzip2 \
+    git
+
+RUN apt-get install -y build-essential cmake pkg-config libjpeg8-dev libtiff5-dev libjasper-dev \
+    libpng12-dev libavcodec-dev libavformat-dev libswscale-dev libv4l-dev libxvidcore-dev libx264-dev \
+    libgtk-3-dev libatlas-base-dev ffmpeg locate libhdf5-dev && updatedb
+
+
+# because opencv 3.1.0 is currently not cuda8.0 compatible, we use an
+# alternative versiion 
+#RUN git clone https://github.com/Itseez/opencv.git && \
+#    cd opencv && git checkout 3.1.0 && \
+RUN git clone https://github.com/daveselinger/opencv && \
+    cd opencv && git checkout 3.1.0-with-cuda8 && \ 
+    cd .. && git clone https://github.com/Itseez/opencv_contrib.git && \
+    cd opencv_contrib && git checkout 3.1.0 && \
+    cd ../opencv && mkdir build && cd build && \
+    cmake -D CMAKE_BUILD_TYPE=RELEASE  \
+    	  -D WITH_CUDA=ON         \
+	  -D CMAKE_INSTALL_PREFIX=/usr/local \
+	  -D OPENCV_EXTRA_MODULES_PATH=/data/opencv_contrib/modules  \
+	  -D CUDA_CUDA_LIBRARY=`locate libcuda.so`  \
+	  -D BUILD_EXAMPLES=ON ..  && \
+    make -j12 && \
+    make install && \
+    ldconfig && \
+    rm -rf /data/opencv /data/opencv_contrib && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    apt-get clean
+
+
+# install datajoint
+RUN pip3 install git+https://github.com/datajoint/datajoint-python.git
+
+
+# --- install HDF5 reader and nose
+RUN pip3 install h5py nose
+
+
+## --- install Spike Triggered Mixture Model for deconvolution
+RUN git clone https://github.com/lucastheis/cmt.git && \
+  cd ./cmt/code/liblbfgs && \
+  ./autogen.sh && \
+  ./configure --enable-sse2 && \
+  make CFLAGS="-fPIC" && \
+  cd ../..  && \
+  python3 setup.py build && \
+  python3 setup.py install
+
+
+RUN pip3 install git+https://github.com/cajal/c2s.git
+
+
+# Instal FFTW (C library) and pyfftw (its python wrapper)
+RUN wget http://www.fftw.org/fftw-3.3.6-pl2.tar.gz && \
+    tar -xvzf fftw-3.3.6-pl2.tar.gz && \
+    cd fftw-3.3.6-pl2 && \
+    ./configure --enable-threads --with-pic --enable-float --enable-sse --enable-sse2 --enable-avx && \
+    make && make install && \
+    ./configure --enable-threads --with-pic --enable-sse2 -enable-avx && \
+    make && make install && \
+    ./configure --enable-threads --with-pic --enable-long-double && \
+    make && make install && \
+    cd .. && rm fftw-3.3.6-pl2.tar.gz && \
+    pip3 install pyfftw
+
+
+# --- install CaImAn
+RUN apt-get update -y -q && \
+    apt-get install -y software-properties-common && \
+    wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.9 main" && \
+    apt-get update -y -q && \
+    apt-get install -y clang-3.9 lldb-3.9 && \
+    apt-get install -y libc6-i386  libsuitesparse-dev && \
+    export LLVM_CONFIG=/usr/lib/llvm-3.9/bin/llvm-config && \ 
+    git clone --recursive https://github.com/ecobost/CaImAn.git && \
+    pip3 install cython scikit-image ipyparallel psutil numba && \
+    pip3 install -r CaImAn/requirements_pip.txt && \
+    pip3 install git+https://github.com/j-friedrich/OASIS.git && \
+    pip3 install future cvxpy
+
+RUN grep -vwE "install_requires=" CaImAn/setup.py > tmp && mv tmp CaImAn/setup.py &&\
+    pip3 install -e CaImAn/
+
+
+RUN pip3 install scikit-learn --upgrade && \
+    pip3 install imreg_dft
+
+RUN pip3 install slacker
+
+ENTRYPOINT ["worker"]

--- a/Dockerfiles/Dockerfile.portainer
+++ b/Dockerfiles/Dockerfile.portainer
@@ -1,6 +1,0 @@
-FROM pipeline:latest
-
-MAINTAINER Edgar Y. Walker, Fabian Sinz
-
-ENTRYPOINT ["worker", "environment"]
-  

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,70 @@
+import os
+from distutils.util import strtobool
+
+from fabric.api import local, abort, run, sudo
+from fabric.context_managers import cd, settings, hide, shell_env
+from fabric.contrib.console import confirm
+from getpass import getpass
+from fabric.utils import puts
+
+from fabric.state import env
+env.builddir = env.builddir if hasattr(env, 'builddir') else '/tmp/'
+
+def on(which):
+    env.hosts = getattr(env, which).split(',')
+
+def ssh():
+    for host in env.hosts:
+        local('ssh-copy-id {}'.format(host))
+
+def with_sudo():
+    """
+    Prompts and sets the sudo password for all following commands.
+
+    Use like
+
+    fab with_sudo command
+    """
+    env.sudo_password = getpass('Please enter sudo password: ')
+    env.password = env.sudo_password
+
+def build_base(nocache=False, pull=False, repo='cajal'):
+    nocache = strtobool(str(nocache))
+    pull = strtobool(str(pull))
+    with cd(env.builddir):
+        with settings(warn_only=True):
+            puts("Cleaning up")
+            run("rm -rf pipeline")
+        run('git clone https://github.com/{}/pipeline.git'.format(repo))
+    with cd(env.builddir + '/pipeline'):
+        args = ''
+        if nocache:
+            args += ' --no-cache'
+        if pull:
+            args += ' --pull'
+
+        sudo('docker build {} -t ninai/pipeline:base -f Dockerfiles/Dockerfile.base .'.format(args))
+
+def push_base():
+    sudo('docker push ninai/pipeline:base')
+
+def build_latest(nocache=False, pull=True, repo='cajal'):
+    nocache = strtobool(str(nocache))
+    pull = strtobool(str(pull))
+    with cd(env.builddir):
+        with settings(warn_only=True):
+            puts("Cleaning up")
+            run("rm -rf pipeline")
+        run('git clone https://github.com/{}/pipeline.git'.format(repo))
+    with cd(env.builddir + '/pipeline'):
+        args = ''
+        if nocache:
+            args += ' --no-cache'
+        if pull:
+            args += ' --pull'
+
+        sudo('docker build {} -t ninai/pipeline:latest .'.format(args))
+
+def push_latest():
+    sudo('docker push ninai/pipeline:latest')
+

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -463,35 +463,6 @@ class MotionCorrection(dj.Computed):
         return my_lambda_function
 
 @schema
-class SummaryImagesCopy(dj.Computed):
-    definition = """ # summary images for each slice and channel after corrections
-
-    -> MotionCorrection
-    -> shared.Channel
-    """
-
-    @property
-    def key_source(self):
-        # Run make_tuples once per scan iff MotionCorrection is done
-        return ScanInfo() & MotionCorrection() & {'reso_version': CURRENT_VERSION}
-
-    class Average(dj.Part):
-        definition = """ # l6-norm of each pixel across time
-
-        -> master
-        ---
-        image           : longblob
-        """
-
-    class Correlation(dj.Part):
-        definition = """ # average temporal correlation between each pixel and its eight neighbors
-
-        -> master
-        ---
-        image           : longblob
-        """
-
-@schema
 class SummaryImages(dj.Computed):
     definition = """ # summary images for each slice and channel after corrections
 

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -462,6 +462,34 @@ class MotionCorrection(dj.Computed):
 
         return my_lambda_function
 
+@schema
+class SummaryImagesCopy(dj.Computed):
+    definition = """ # summary images for each slice and channel after corrections
+
+    -> MotionCorrection
+    -> shared.Channel
+    """
+
+    @property
+    def key_source(self):
+        # Run make_tuples once per scan iff MotionCorrection is done
+        return ScanInfo() & MotionCorrection() & {'reso_version': CURRENT_VERSION}
+
+    class Average(dj.Part):
+        definition = """ # l6-norm of each pixel across time
+
+        -> master
+        ---
+        image           : longblob
+        """
+
+    class Correlation(dj.Part):
+        definition = """ # average temporal correlation between each pixel and its eight neighbors
+
+        -> master
+        ---
+        image           : longblob
+        """
 
 @schema
 class SummaryImages(dj.Computed):
@@ -479,17 +507,17 @@ class SummaryImages(dj.Computed):
     class Average(dj.Part):
         definition = """ # l6-norm of each pixel across time
 
-        -> SummaryImages
+        -> master
         ---
-        image           : longblob
+        average_image           : longblob
         """
 
     class Correlation(dj.Part):
         definition = """ # average temporal correlation between each pixel and its eight neighbors
 
-        -> SummaryImages
+        -> master
         ---
-        image           : longblob
+        correlation_image           : longblob
         """
 
     def _make_tuples(self, key):
@@ -521,13 +549,13 @@ class SummaryImages(dj.Computed):
 
                 # Compute and insert correlation image
                 correlation_image = ci.compute_correlation_image(scan_)
-                SummaryImages.Correlation().insert1({**tuple_, 'image': correlation_image})
+                SummaryImages.Correlation().insert1({**tuple_, 'correlation_image': correlation_image})
 
                 # Compute and insert lp-norm of each pixel over time
                 p = 6
                 scan_ = np.power(scan_, p, out=scan_)  # in place
                 average_image = np.sum(scan_, axis=-1, dtype=np.float64) ** (1 / p)
-                SummaryImages.Average().insert1({**tuple_, 'image': average_image})
+                SummaryImages.Average().insert1({**tuple_, 'average_image': average_image})
 
                 # Free memory
                 del scan_
@@ -548,8 +576,8 @@ class SummaryImages(dj.Computed):
         for channel in range(num_channels):
             axes[channel, 0].set_ylabel('Channel {}'.format(channel + 1), size='large',
                                         rotation='horizontal', ha='right')
-            corr = (SummaryImages.Correlation() & key & {'channel': channel + 1}).fetch1('image')
-            avg = (SummaryImages.Average() & key & {'channel': channel + 1}).fetch1('image')
+            corr = (SummaryImages.Correlation() & key & {'channel': channel + 1}).fetch1('correlation_image')
+            avg = (SummaryImages.Average() & key & {'channel': channel + 1}).fetch1('average_image')
             axes[channel, 0].imshow(avg)
             axes[channel, 1].imshow(corr)
 
@@ -934,7 +962,7 @@ class Segmentation(dj.Computed):
         # Get correlation image if defined, black background otherwise.
         image_rel = SummaryImages.Correlation() & self
         if image_rel:
-            background_image = image_rel.fetch1('image')
+            background_image = image_rel.fetch1('correlation_image')
         else:
             background_image = np.zeros(masks.shape[:-1])
 
@@ -1048,7 +1076,7 @@ class MaskClassification(dj.Computed):
 
         # Classify masks
         if key['classification_method'] == 1:  # manual
-            template = (SummaryImages.Correlation() & key).fetch1('image')
+            template = (SummaryImages.Correlation() & key).fetch1('correlation_image')
             mask_types = mask_classification.classify_manual(masks, template)
         elif key['classification_method'] == 2:  # cnn
             raise PipelineException('Convnet not yet implemented.')
@@ -1179,7 +1207,7 @@ class ScanSet(dj.Computed):
         # Get correlation image if defined, black background otherwise.
         image_rel = SummaryImages.Correlation() & self
         if image_rel:
-            background_image = image_rel.fetch1('image')
+            background_image = image_rel.fetch1('correlation_image')
         else:
             image_height, image_width = (ScanInfo() & self).fetch1('px_height', 'px_width')
             background_image = np.zeros([image_height, image_width])


### PR DESCRIPTION
- I split the lengthy build part of the docker file into a separate one. That needs to be built less frequent and we can do that locally here. With the split, we can get automatic builds on Dockerhub back. 
- To build it locally, I built a fabfile. After installing `fabric3` one can compile the entire pipeline with `fab -H COMPUTERNAME build_base:1,1,'cajal' build_latest:1,0,'cajal'`. There are also recipes to push the images. 
- I also renamed the attribute names in the part tables for summary images. Before they all were names `image` which is annoying when joining the part tables. I already moved the underlying database. 