### PR TITLE
Mask Classification and some improvements to MotionCorrection

### DIFF
--- a/Dockerfiles/Dockerfile.base
+++ b/Dockerfiles/Dockerfile.base
@@ -97,6 +97,7 @@ RUN apt-get update -y -q && \
     pip3 install -r CaImAn/requirements_pip.txt && \
     pip3 install git+https://github.com/j-friedrich/OASIS.git && \
     pip3 install future cvxpy
+    pip3 install keras
 
 RUN grep -vwE "install_requires=" CaImAn/setup.py > tmp && mv tmp CaImAn/setup.py &&\
     pip3 install -e CaImAn/

--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -1000,7 +1000,6 @@ class MaskClassification(dj.Computed):
     definition = """ # classification of segmented masks.
 
     -> Segmentation                     # animal_id, session, scan_idx, reso_version, field, channel, segmentation_method
-    -> SummaryImages                    # animal_id, session, scan_idx, reso_version, field, channel
     -> shared.ClassificationMethod
     ---
     classif_time=CURRENT_TIMESTAMP    : timestamp     # automatic
@@ -1028,6 +1027,10 @@ class MaskClassification(dj.Computed):
 
         # Classify masks
         if key['classification_method'] == 1:  # manual
+            if not SummaryImages() & key:
+                msg = 'Need to populate SummaryImages before manual mask classification'
+                raise PipelineException(msg)
+
             template = (SummaryImages.Correlation() & key).fetch1('correlation_image')
             masks = masks.transpose([2, 0, 1])  # num_masks, image_height, image_width
             mask_types = mask_classification.classify_manual(masks, template)

--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -300,8 +300,8 @@ class MotionCorrection(dj.Computed):
             # Get motion correction shifts
             results = galvo_corrections.compute_motion_shifts(scan_, template,
                                                               smoothing_window_size=window_size)
-            y_shifts = results[0] - results[0].mean()  # center motions around zero
-            x_shifts = results[1] - results[1].mean()
+            y_shifts = results[0] - np.median(results[0])  # center motions around zero
+            x_shifts = results[1] - np.median(results[1])
             tuple_['y_shifts'] = y_shifts
             tuple_['x_shifts'] = x_shifts
             tuple_['y_outlier_frames'] = results[2]

--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -296,7 +296,6 @@ class MotionCorrection(dj.Computed):
             # Compute smoothing window size
             size_in_ms = 300  # smooth over a 300 milliseconds window
             window_size = int(round(scan.fps * (size_in_ms / 1000)))  # in frames
-            window_size += 1 if window_size % 2 == 0 else 0  # make odd
 
             # Get motion correction shifts
             results = galvo_corrections.compute_motion_shifts(scan_, template,

--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -1074,7 +1074,6 @@ class ScanSet(dj.Computed):
 
         -> ScanSet.Unit
         ---
-        -> shared.MaskType                  # type of the unit
         um_x                : smallint      # x-coordinate of centroid in motor coordinate system
         um_y                : smallint      # y-coordinate of centroid in motor coordinate system
         um_z                : smallint      # z-coordinate of mask relative to surface of the cortex
@@ -1102,14 +1101,6 @@ class ScanSet(dj.Computed):
         px_centroids = cmn.get_centroids(masks)
         um_centroids = um_center + (px_centroids - px_center) * (ScanInfo.Field() & key).microns_per_pixel
 
-        # Get type from MaskClassification if available, else SegmentationTask
-        if MaskClassification() & key:
-            ids, types = (MaskClassification.Type() & key).fetch('mask_id', 'type')
-            get_type = lambda mask_id: types[ids == mask_id].item()
-        else:
-            mask_type = (SegmentationTask() & key).fetch1('compartment')
-            get_type = lambda mask_id: mask_type
-
         # Compute units' delays
         delay_image = (ScanInfo.Field() & key).fetch1('delay_image')
         delays = (np.sum(masks * np.expand_dims(delay_image, -1), axis=(0, 1)) /
@@ -1129,9 +1120,8 @@ class ScanSet(dj.Computed):
                                                                        um_centroids, px_centroids, delays):
             ScanSet.Unit().insert1({**key, 'unit_id': unit_id, 'mask_id': mask_id})
 
-            unit_info = {**key, 'unit_id': unit_id, 'type': get_type(mask_id),
-                         'um_x': um_x, 'um_y': um_y, 'um_z': um_z, 'px_x': px_x,
-                         'px_y': px_y, 'ms_delay': delay}
+            unit_info = {**key, 'unit_id': unit_id, 'um_x': um_x, 'um_y': um_y,
+                         'um_z': um_z, 'px_x': px_x, 'px_y': px_y, 'ms_delay': delay}
             ScanSet.UnitInfo().insert1(unit_info, ignore_extra_fields=True)  # ignore field and channel
 
         self.notify(key)

--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -1008,7 +1008,7 @@ class MaskClassification(dj.Computed):
 
     @property
     def key_source(self):
-        return (Segmentation() * SummaryImages() * shared.ClassificationMethod() &
+        return (Segmentation() * shared.ClassificationMethod() &
                 {'meso_version': CURRENT_VERSION})
 
     class Type(dj.Part):

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -292,8 +292,8 @@ class MotionCorrection(dj.Computed):
             # Get motion correction shifts
             results = galvo_corrections.compute_motion_shifts(scan_, template,
                                                               smoothing_window_size=window_size)
-            y_shifts = results[0] - results[0].mean()  # center motions around zero
-            x_shifts = results[1] - results[1].mean()
+            y_shifts = results[0] - np.median(results[0])  # center motions around zero
+            x_shifts = results[1] - np.median(results[1])
             tuple_['y_shifts'] = y_shifts
             tuple_['x_shifts'] = x_shifts
             tuple_['y_outlier_frames'] = results[2]

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -288,7 +288,6 @@ class MotionCorrection(dj.Computed):
             # Compute smoothing window size
             size_in_ms = 300  # smooth over a 300 milliseconds window
             window_size = int(round(scan.fps * (size_in_ms / 1000)))  # in frames
-            window_size += 1 if window_size % 2 == 0 else 0  # make odd
 
             # Get motion correction shifts
             results = galvo_corrections.compute_motion_shifts(scan_, template,

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -999,7 +999,6 @@ class MaskClassification(dj.Computed):
     definition = """ # classification of segmented masks.
 
     -> Segmentation                     # animal_id, session, scan_idx, reso_version, slice, channel, segmentation_method
-    -> SummaryImages                    # animal_id, session, scan_idx, reso_version, slice, channel
     -> shared.ClassificationMethod
     ---
     classif_time=CURRENT_TIMESTAMP    : timestamp     # automatic
@@ -1027,6 +1026,10 @@ class MaskClassification(dj.Computed):
 
         # Classify masks
         if key['classification_method'] == 1:  # manual
+            if not SummaryImages() & key:
+                msg = 'Need to populate SummaryImages before manual mask classification'
+                raise PipelineException(msg)
+
             template = (SummaryImages.Correlation() & key).fetch1('correlation_image')
             masks = masks.transpose([2, 0, 1])  # num_masks, image_height, image_width
             mask_types = mask_classification.classify_manual(masks, template)

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -1024,16 +1024,17 @@ class MaskClassification(dj.Computed):
         image_height, image_width = (ScanInfo() & key).fetch1('px_height', 'px_width')
         mask_ids, pixels, weights = (Segmentation.Mask() & key).fetch('mask_id', 'pixels', 'weights')
         masks = Segmentation.reshape_masks(pixels, weights, image_height, image_width)
-        masks = masks.transpose([2, 0, 1])  # num_masks, image_height, image_width
 
         # Classify masks
         if key['classification_method'] == 1:  # manual
             template = (SummaryImages.Correlation() & key).fetch1('correlation_image')
+            masks = masks.transpose([2, 0, 1])  # num_masks, image_height, image_width
             mask_types = mask_classification.classify_manual(masks, template)
-        elif key['classification_method'] == 2:  # cnn
-            raise PipelineException('Convnet not yet implemented.')
-            # template = (SummaryImages.Correlation() & key).fetch1('image')
-            # mask_types = mask_classification.classify_cnn(masks, template)
+        elif key['classification_method'] == 2:  # cnn-caiman
+            from .utils import caiman_interface as cmn
+            soma_diameter = tuple(14 / (ScanInfo() & key).microns_per_pixel)
+            probs = cmn.classify_masks(masks, soma_diameter)
+            mask_types = ['soma' if prob > 0.75 else 'artifact' for prob in probs]
         else:
             msg = 'Unrecognized classification method {}'.format(key['classification_method'])
             raise PipelineException(msg)
@@ -1044,6 +1045,67 @@ class MaskClassification(dj.Computed):
         self.insert1(key)
         for mask_id, mask_type in zip(mask_ids, mask_types):
             MaskClassification.Type().insert1({**key, 'mask_id': mask_id, 'type': mask_type})
+
+        self.notify(key, mask_types)
+
+    def notify(self, key, mask_types):
+        mask_names = ['soma', 'axon', 'dendrite', 'neuropil', 'artifact', 'unknown']
+        mask_counts = [mask_types.count(name) for name in mask_names]
+
+        fig = (MaskClassification() & key).plot_masks()
+        img_filename = '/tmp/' + key_hash(key) + '.png'
+        fig.savefig(img_filename)
+        plt.close(fig)
+
+        msg = 'MaskClassification for `{}` has been populated.\n'.format(key)
+        msg += ', '.join('{} {}s'.format(c, n) for c, n in zip(mask_counts, mask_names))
+        (notify.SlackUser() & (experiment.Session() & key)).notify(msg, file=img_filename,
+                                                                   file_title='mask classes')
+
+    def plot_masks(self, threshold=0.99):
+        """ Draw contours of masks over the correlation image (if available) with different
+        colors per type
+
+        :param threshold: Threshold on the cumulative mass to define mask contours. Lower
+            for tighter contours.
+
+        :returns Figure. You can call show() on it.
+        :rtype: matplotlib.figure.Figure
+        """
+        # Get masks
+        masks = (Segmentation() & self).get_all_masks()
+        mask_types = (MaskClassification.Type() & self).fetch('type')
+        colormap = {'soma': 'b', 'axon': 'k', 'dendrite': 'c', 'neuropil': 'y',
+                    'artifact': 'r', 'unknown': 'w'}
+
+
+        # Get correlation image if defined, black background otherwise.
+        image_rel = SummaryImages.Correlation() & self
+        if image_rel:
+            background_image = image_rel.fetch1('correlation_image')
+        else:
+            background_image = np.zeros(masks.shape[:-1])
+
+        # Plot background
+        image_height, image_width, num_masks = masks.shape
+        figsize = np.array([image_width, image_height]) / min(image_height, image_width)
+        fig = plt.figure(figsize=figsize * 7)
+        plt.imshow(background_image)
+
+        # Draw contours
+        cumsum_mask = np.empty([image_height, image_width])
+        for i in range(num_masks):
+            mask = masks[:, :, i]
+            color = colormap[mask_types[i]]
+
+            ## Compute cumulative mass (similar to caiman)
+            indices = np.unravel_index(np.flip(np.argsort(mask, axis=None), axis=0), mask.shape) # max to min value in mask
+            cumsum_mask[indices] = np.cumsum(mask[indices]**2) / np.sum(mask**2)
+
+            ## Plot contour at desired threshold
+            plt.contour(cumsum_mask, [threshold], linewidths=0.8, colors=[color])
+
+        return fig
 
 
 @schema

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -1007,7 +1007,7 @@ class MaskClassification(dj.Computed):
 
     @property
     def key_source(self):
-        return (Segmentation() * SummaryImages() * shared.ClassificationMethod() &
+        return (Segmentation() * shared.ClassificationMethod() &
                 {'reso_version': CURRENT_VERSION})
 
     class Type(dj.Part):

--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -685,18 +685,6 @@ class Segmentation(dj.Computed):
             kwargs['num_processes'] = 12  # Set to None for all cores available
             kwargs['num_pixels_per_process'] = 10000
 
-
-
-
-
-            ## Test
-            #scan_ = scan_[:, :]
-
-
-
-
-
-
             # Save as memory mapped file (as expected by CaImAn)
             print('Creating memory mapped file...')
             mmap_scan = cmn._save_as_memmap(scan_, base_name='/tmp/caiman-{}'.format(uuid.uuid4()))
@@ -714,26 +702,6 @@ class Segmentation(dj.Computed):
             # Insert CNMF results
             print('Inserting masks, background components and traces...')
             dj.conn()
-
-
-
-
-
-
-            # TEST
-#            num_masks = masks.shape[-1]
-#            new_masks = np.zeros([256, 256, num_masks])
-#            new_masks[:, :, :] = masks
-#            masks = new_masks
-#
-#            num_background_masks = background_masks.shape[-1]
-#            new_background_masks = np.zeros([256, 256, num_background_masks])
-#            new_background_masks[:, :, :] = background_masks
-#            background_masks = new_background_masks
-
-
-
-
 
             ## Insert in CNMF, Segmentation and Fluorescence
             Segmentation().insert1(key)

--- a/python/pipeline/shared.py
+++ b/python/pipeline/shared.py
@@ -53,7 +53,7 @@ class ClassificationMethod(dj.Lookup):
 
     contents = [
     [1, 'manual', 'masks classified by visual inspection', 'python'],
-    [2, 'cnn', 'classification made by a trained convolutional network', 'python']
+    [2, 'cnn-caiman', 'classification made by a trained convolutional network', 'python']
     ]
 
 @schema

--- a/python/pipeline/utils/caiman_interface.py
+++ b/python/pipeline/utils/caiman_interface.py
@@ -85,18 +85,20 @@ def extract_masks(scan, mmap_scan, num_components=200, num_background_components
         patch_overlap = np.int32(np.round(patch_size * proportion_patch_overlap))
 
         # Create options dictionary (needed for run_CNMF_patches)
-        options = {'patch_params': {'only_init': True, 'remove_very_bad_comps': False, # remove_very_bads_comps unnecesary (same as default)
-                                    'ssub': 'UNUSED.', 'tsub': 'UNUSED',
-                                    'skip_refinement': 'UNUSED.'},
+        options = {'patch_params': {'ssub': 'UNUSED.', 'tsub': 'UNUSED', 'nb': num_background_components,
+                                    'only_init': True, 'skip_refinement': 'UNUSED.',
+                                    'remove_very_bad_comps': False}, # remove_very_bads_comps unnecesary (same as default)
                    'preprocess_params': {'check_nan': False}, # check_nan is unnecessary (same as default value)
                    'spatial_params': {'nb': num_background_components}, # nb is unnecessary, it is pased to the function and in init_params
                    'temporal_params': {'p': 0, 'method': 'UNUSED.', 'block_size': 'UNUSED.'},
                    'init_params': {'K': num_components_per_patch, 'gSig': np.array(soma_diameter)/2,
-                                   'method': init_method, 'alpha_snmf': snmf_alpha,
+                                   'gSiz': None, 'method': init_method, 'alpha_snmf': snmf_alpha,
                                    'nb': num_background_components, 'ssub': 1, 'tsub': max(int(fps / 5), 1),
                                    'options_local_NMF': 'UNUSED.', 'normalize_init': True,
-                                   'rolling_sum': True, 'rolling_length': 100},
-                                   # ssub, tsub, options_local_NMF, normalize_init, rolling_sum unnecessary (same as default values)
+                                   'rolling_sum': True, 'rolling_length': 100, 'min_corr': 'UNUSED',
+                                   'min_pnr': 'UNUSED', 'deconvolve_options_init': 'UNUSED',
+                                   'ring_size_factor': 'UNUSED', 'center_psf': 'UNUSED'},
+                                   # gSiz, ssub, tsub, options_local_NMF, normalize_init, rolling_sum unnecessary (same as default values)
                    'merging' : {'thr': 'UNUSED.'}}
 
         # Initialize per patch
@@ -159,7 +161,7 @@ def extract_masks(scan, mmap_scan, num_components=200, num_background_components
     res = temporal.update_temporal_components(mmap_scan, A, b, C, f, nb=num_background_components,
                                               block_size=10000, p=0, method='cvxpy',
                                               dview=direct_view)
-    C, A, b, f, S, bl, c1, neurons_noise, g, YrA = res
+    C, A, b, f, S, bl, c1, neurons_noise, g, YrA, _ = res
 
 
     # Merge components
@@ -184,7 +186,7 @@ def extract_masks(scan, mmap_scan, num_components=200, num_background_components
     res = temporal.update_temporal_components(mmap_scan, A, b, C, f, nb=num_background_components,
                                               block_size=10000, p=0, method='cvxpy',
                                               dview=direct_view)
-    C, A, b, f, S, bl, c1, neurons_noise, g, YrA = res
+    C, A, b, f, S, bl, c1, neurons_noise, g, YrA, _ = res
 
     # Removing bad components (more stringent criteria)
     log('Removing bad components...')
@@ -390,8 +392,6 @@ def get_centroids(masks):
     centroids = np.array([coordinate['CoM'] for coordinate in coordinates])
 
     return centroids
-
-
 
 
 

--- a/python/pipeline/utils/caiman_interface.py
+++ b/python/pipeline/utils/caiman_interface.py
@@ -394,6 +394,27 @@ def get_centroids(masks):
     return centroids
 
 
+def classify_masks(masks, soma_diameter=(14, 14)):
+    """ Uses a convolutional network to predict the probability per mask of being a soma.
+
+    :param np.array masks: Masks (image_height x image_width x num_components)
+
+    :returns: Soma predictions (num_components).
+    """
+    # Reshape masks
+    image_height, image_width, num_components = masks.shape
+    masks = masks.reshape(-1, num_components, order='F')
+
+    # Prepare input
+    from scipy.sparse import coo_matrix
+    masks = coo_matrix(masks)
+    soma_radius = np.int32(np.round(np.array(soma_diameter)/2))
+
+    model_path = '/data/CaImAn/use_cases/CaImAnpaper/cnn_model'
+    probs, _ = components_evaluation.evaluate_components_CNN(masks, (image_height, image_width),
+                                                             soma_radius, model_name=model_path)
+
+    return probs[:, 1]
 
 
 

--- a/python/pipeline/utils/galvo_corrections.py
+++ b/python/pipeline/utils/galvo_corrections.py
@@ -217,12 +217,12 @@ def correct_raster(scan, raster_phase, temporal_fill_fraction, in_place=True):
 
         # Correct even rows of the image (0, 2, ...)
         interp_function = interp.interp1d(scan_angles, image[::2, :], bounds_error=False,
-                                          fill_value='extrapolate', copy=False)
+                                          fill_value=0, copy=(not in_place))
         reshaped_scan[::2, :, i] = interp_function(scan_angles + raster_phase)
 
         # Correct odd rows of the image (1, 3, ...)
         interp_function = interp.interp1d(scan_angles, image[1::2, :], bounds_error=False,
-                                          fill_value='extrapolate', copy=False)
+                                          fill_value=0, copy=(not in_place))
         reshaped_scan[1::2, :, i] = interp_function(scan_angles - raster_phase)
 
     scan = np.reshape(reshaped_scan, original_shape)
@@ -281,7 +281,8 @@ def correct_motion(scan, xy_shifts, in_place=True):
 
             # Create interpolation function
             interp_function = interp.interp2d(range(image_width), range(image_height),
-                                              image, kind='cubic', copy=False)
+                                              image, kind='linear', fill_value=0,
+                                              copy=(not in_place))
 
             # Evaluate on the original image plus offsets
             reshaped_scan[:, :, i] = interp_function(np.arange(image_width) + x_shift,

--- a/python/pipeline/utils/signal.py
+++ b/python/pipeline/utils/signal.py
@@ -22,22 +22,25 @@ def normalize(img):
     return (img - img.min()) / (img.max() - img.min())
 
 
-def mirrconv(s, h):
+def mirrconv(signal, f):
+    """ Convolution with mirrored ends to avoid edge artifacts.
+
+    :param np.array signal: One-dimensional signal.
+    :param np.array f: One-dimensional filter (length should be odd).
+    :returns: Filtered signal (same length as signal)
     """
-    Convolution where the ends are mirrored to have the same signal statistic.
+    if signal.ndim != 1 or f.ndim != 1:
+       raise ValueError('Only one-dimensional signals allowed.')
+    if len(f) % 2 != 1:
+        raise ValueError('Filter must have odd length')
+    if len(f) < 3:
+        return signal
 
-    Only works for one dimensional arrays/
+    n = len(f) // 2
+    padded_signal = np.hstack((signal[n - 1::-1], signal, signal[:-n - 1:-1]))
+    filtered_signal = np.convolve(padded_signal, f, mode='valid')
 
-    :param s: signal
-    :param h: filter (length must be odd)
-    :return: filtered signal of the same length
-    """
-    assert s.ndim == 1, "Only one dimensional signals allowed!"
-    assert h.ndim == 1, "Only one dimensional filters allowed!"
-    assert len(h) % 2 == 1, "Filter must have odd length"
-
-    n = h.size // 2
-    return np.convolve(np.hstack((s[n-1::-1], s, s[:-n-1:-1])), h, mode='valid')
+    return filtered_signal
 
 
 def local_max(x):


### PR DESCRIPTION
Add automatic mask classfiication using CaImAn's convnet and also modify Segmentation to work with latest version of caiman (no online yet, though).
In motion correction, use linear rather than cubic interpolation (faster and very similar results), fill in out-of-bounds values with zero rather than extrapolate and center motion shifts using the median rather than the mean to decrease outlier/black frame leverage.
Also drop type from ScanSet.UnitInfo. Now, unit types will only be in MaskClassification.Type


