### PR TITLE
minor

### DIFF
--- a/python/pipeline/experiment.py
+++ b/python/pipeline/experiment.py
@@ -364,7 +364,7 @@ class HasFilename:
         scan_path = (Session() & self).fetch1('scan_path')
         local_path = lab.Paths().get_local_path(scan_path)
 
-        scan_name = (self.__class__() & self).fetch1('filename')
+        scan_name = (self.__class__() & self.proj()).fetch1('filename')
         local_filename = os.path.join(local_path, scan_name) + '*.tif'  # all parts
 
         return local_filename


### PR DESCRIPTION
minor fix for datajoint 0.10.0+ compatibility

Starting in datajoint 0.10.0,  restriction of a relation with another relation cannot be done on attributes that are not part of the primary key in either of the operands.