### PR TITLE
Bug fixes in treadmill

### DIFF
--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -155,6 +155,8 @@ class Treadmill(dj.Computed):
         for start, stop in zip(nan_limits[::2], nan_limits[1::2]):
             lower_ts = float('-inf') if start == 0 else ts[start - 1]
             upper_ts = float('inf') if stop == len(ts) else ts[stop]
+            timestamps_in_secs[np.logical_and(timestamps_in_secs > lower_ts,
+                                              timestamps_in_secs < upper_ts)] = float('nan')
             velocity[np.logical_and(timestamps_in_secs > lower_ts,
                                     timestamps_in_secs < upper_ts)] = float('nan')
 

--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -39,7 +39,7 @@ class Sync(dj.Computed):
         timestamps_in_secs = h5.ts2sec(data['ts'], is_packeted=True)
 
         # Detect rising edges in scanimage clock signal (start of each frame)
-        binarized_signal = data['scanImage'] > 2.4 # TTL voltage low/high threshold
+        binarized_signal = data['scanImage'] > 2.7 # TTL voltage low/high threshold
         rising_edges = np.where(np.diff(binarized_signal.astype(int)) > 0)[0]
         frame_times = timestamps_in_secs[rising_edges]
 

--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -46,7 +46,7 @@ class Sync(dj.Computed):
         # Correct NaN gaps in timestamps (mistimed or dropped packets during recording)
         if np.any(np.isnan(frame_times)):
             # Raise exception if first or last frame pulse was recorded in mistimed packet
-            if np.isnan(frame_times[0]) or np.isnan(frame_times[1]):
+            if np.isnan(frame_times[0]) or np.isnan(frame_times[-1]):
                 msg = ('First or last frame happened during misstamped packets. Pulses '
                        'could have been missed: start/end of scanning is unknown.')
                 raise PipelineException(msg)

--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -155,10 +155,9 @@ class Treadmill(dj.Computed):
         for start, stop in zip(nan_limits[::2], nan_limits[1::2]):
             lower_ts = float('-inf') if start == 0 else ts[start - 1]
             upper_ts = float('inf') if stop == len(ts) else ts[stop]
-            timestamps_in_secs[np.logical_and(timestamps_in_secs > lower_ts,
-                                              timestamps_in_secs < upper_ts)] = float('nan')
             velocity[np.logical_and(timestamps_in_secs > lower_ts,
                                     timestamps_in_secs < upper_ts)] = float('nan')
+        timestamps_in_secs[np.isnan(velocity)] = float('nan')
 
         # Insert
         self.insert1({**key, 'treadmill_time': timestamps_in_secs,

--- a/python/pipeline/utils/h5.py
+++ b/python/pipeline/utils/h5.py
@@ -37,8 +37,8 @@ def ts2sec(ts, sampling_rate=1e7, is_packeted=False):
         ts_secs = np.interp(sample_xs, xs, ys)
 
         # Invalidate timepoints with unequal spacing between packets
-        if np.any(abs(np.diff(ys) - expected_length) > 0.15 * expected_length):
-            abnormal_diffs = abs(np.diff(ys) - expected_length) > 0.15 * expected_length
+        if np.any(abs(np.diff(ys) - expected_length) > 0.1 * expected_length):
+            abnormal_diffs = abs(np.diff(ys) - expected_length) > 0.1 * expected_length
             abnormal_limits = np.where(np.diff([0, *abnormal_diffs, 0]))[0]
             for start, stop in zip(abnormal_limits[::2], abnormal_limits[1::2]):
                 abnormal_indices = np.logical_and(sample_xs > xs[start], sample_xs < xs[stop])

--- a/python/pipeline/utils/h5.py
+++ b/python/pipeline/utils/h5.py
@@ -114,7 +114,8 @@ def read_behavior_file(hdf5_path):
             data['framenum_ts'] = np.array(f['framenum_ts'])
             data['trialnum_ts'] = np.array(f['trialnum_ts'])
             data['eyecam_ts'] = np.array(f['videotimestamps'])
-            data['posture_ts'] = np.array(f['videotimestamps_posture'])
+            if 'videotimestamps_posture' in f:
+                data['posture_ts'] = np.array(f['videotimestamps_posture'])
 
             analog_signals = np.array(f['Analog Signals'])
             channel_names = f.attrs['AS_channelNames'].decode('ascii').split(',')


### PR DESCRIPTION
Change threshold to consider a packet mistamped from 30 msecs to 20 msecs
Fix checking whether last position in the frame times is NaN
When setting velocity to NaN in treadmill, set their respective timepoints to NaN, too
