### PR TITLE
bug fixed

### DIFF
--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -684,6 +684,15 @@ class Tracking(dj.Computed):
 
             else:
                 print('{} already exists!'.format(tracking_dir))
+                print('Removing existing tracking directory and recreating')
+
+                os.shutil.rmtree(tracking_dir)
+
+                os.mkdir(tracking_dir)
+                os.mkdir(os.path.join(tracking_dir, 'compressed_cropped'))
+                os.mkdir(os.path.join(tracking_dir, 'short'))
+
+                os.link(vid_path, hardlink_path)
 
             return tracking_dir, hardlink_path
 

--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -19,7 +19,7 @@ from datajoint.jobs import key_hash
 from datajoint.autopopulate import AutoPopulate
 
 from .utils.decorators import gitlog
-from .utils import eye_tracking, h5, filter_config
+from .utils import eye_tracking, h5
 from .utils.eye_tracking import PupilTracker, ManualTracker
 from . import config
 from . import experiment, notify, shared

--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -686,7 +686,7 @@ class Tracking(dj.Computed):
                 print('{} already exists!'.format(tracking_dir))
                 print('Removing existing tracking directory and recreating')
 
-                os.shutil.rmtree(tracking_dir)
+                shutil.rmtree(tracking_dir)
 
                 os.mkdir(tracking_dir)
                 os.mkdir(os.path.join(tracking_dir, 'compressed_cropped'))


### PR DESCRIPTION
1. deleted `filter_config` import 
2. updated the way `tracking_dir` is created. Now, if the `tracking_dir` exists, it will delete that directory and recreate, and repopulate and go through the tracking process.