### PR TITLE
Convert external-odor to longblob

### DIFF
--- a/python/pipeline/odor.py
+++ b/python/pipeline/odor.py
@@ -10,8 +10,8 @@ from pipeline.utils import h5
 from commons import lab
 
 
-dj.config['external-odor'] = {'protocol': 'file',
-                              'location': '/mnt/dj-stor01/pipeline-externals'}
+#dj.config['external-odor'] = {'protocol': 'file',
+#                              'location': '/mnt/dj-stor01/pipeline-externals'}
 
 schema = dj.schema('pipeline_odor', locals(), create_tables=False)
 
@@ -214,8 +214,8 @@ class Respiration(dj.Imported):
     definition = """ # Analog recording of mouse respiration
     -> OdorRecording
     ---
-    trace                       : external-odor        # mouse respiration (arbitrary units)
-    times                       : external-odor        # trace times on olfactory clock (seconds)
+    trace                       : longblob             # mouse respiration (arbitrary units)
+    times                       : longblob             # trace times on olfactory clock (seconds)
     """
 
     def make(self, key):


### PR DESCRIPTION
Due to issues with collaborators, temporarily switching odor.Respiration to use longblobs instead of externals.