### PR TITLE
Add clocktools, pupil processing, treadmill processing

### DIFF
--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -1348,11 +1348,11 @@ class PupilPeriods(dj.Computed):
         -> PupilPeriods
         period_idx                : smallint unsigned
         ---
-        period_onset              : float               # period start time (in seconds)
-        period_offset             : float               # period stop time (in seconds)
-        peak_change_time          : float               # time (in seconds) at which peak change rate occurs
-        period_delta              : float               # overall change in size (in pixels, as a placeholder for now)
-        period_duration           : float               # period duration (in seconds)
+        period_onset              : float               # (sec) period start time
+        period_offset             : float               # (sec) period stop time
+        peak_change_time          : float               # (sec) time at which peak change rate occurs
+        period_delta              : float               # (mm) overall change in size (dilation > 0, constriction < 0)
+        period_duration           : float               # (sec) period duration
         """
         
     def _make_tuples(self, key):

--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -32,6 +32,7 @@ import datajoint as dj
 from datajoint.jobs import key_hash
 from datajoint.autopopulate import AutoPopulate
 
+from .utils import clocktools
 from .utils.decorators import gitlog
 from .utils import eye_tracking, h5
 from .utils.eye_tracking import PupilTracker, ManualTracker
@@ -43,6 +44,7 @@ from IPython import display
 import pylab as pl
 import matplotlib.pyplot as plt
 from matplotlib.patches import Ellipse
+from scipy import interpolate
 import time
 import datetime
 
@@ -1149,6 +1151,352 @@ def plot_fitting(key, start, end=-1, fit_type='Circle', fig=None, ax=None, mask_
         else:
             pupil_fit.plot_fitted_multi_frames(
                 start=start, end=end, fitting_method=fit_type)
+
+
+@schema
+class PupilFilterMethod(dj.Lookup):
+    definition = """ # Method to filter pupil trace
+    pupil_method_id               : tinyint unsigned    # index for pupil filter method
+    ---
+    -> shared.FilterMethod
+    pupil_source                  : enum("Circle", "Ellipse")
+    radius_type                   : enum("radius", "major_radius", "minor_radius")
+    """
+    
+    contents = [[1, '1Hz Hamming Lowpass', 'Circle', 'radius'],
+                [2, '2Hz Hamming Lowpass', 'Circle', 'radius']]
+    
+
+@schema
+class ProcessedPupil(dj.Computed):
+    definition = """ # Filtered pupil trace for further processing with pupil
+    -> FittedPupil
+    -> PupilFilterMethod
+    ---
+    valid_start                   : float        # (sec) pupil trace non-nan start time on Behavior clock
+    valid_end                     : float        # (sec) pupil trace non-nan end time on Behavior clock
+    valid_fraction                : float        # fraction of non-nan frames within valid start/end
+    longest_valid_epoch           : float        # (sec) longest continuous period of non-nan frames
+    mean_radius                   : float        # (pixels) mean pupil radius in pixels (ignoring nans)
+    radius_95                     : float        # (pixels) 95th percentile of radius
+    filtered_pupil_radius         : longblob     # radius trace after filtering
+    filtered_pupil_center         : longblob     # center trace after filtering
+    pupil_sampling_rate           : float        # (Hz) sampling rate of pupil (Hz)
+    """
+    
+    @property
+    def key_source(self):
+        deeplabcut_fitting = FittedPupil & {'tracking_method': 2}
+        return deeplabcut_fitting * PupilFilterMethod
+    
+    def _make_tuples(self, key):
+
+        print(f'Generating ProcessedPupil for {key}')
+        
+        ## Fetch times and fps
+        eye_times = (Eye & key).fetch1('eye_time')
+        pupil_fps = 1/np.nanmedian(np.diff(eye_times))
+
+        ## Fetch radii and radius centers over time
+        pupil_source = (PupilFilterMethod & key).fetch('pupil_source')
+        if pupil_source == 'Circle':
+            source_table = FittedPupil.Circle
+        elif pupil_source == 'Ellipse':
+            source_table = FittedPupil.Ellipse
+        radius_type = (PupilFilterMethod & key).fetch1('radius_type')
+        pupil_radii = (source_table & key).fetch(radius_type)
+        pupil_centers = (source_table & key).fetch('center')
+
+        ## Define valid start and ending times
+        start_index = np.nanargmin(eye_times)
+        valid_start = eye_times[start_index]
+        end_index = np.nanargmax(eye_times)
+        valid_end = eye_times[end_index]
+
+        ## Calculate fraction of non-NaN to NaN entries in signal
+        valid_fraction = len(np.where(~np.isnan(pupil_radii))[0])/(end_index-start_index)
+
+        ## Find longest string of non-NaN radii. First find non-NaN indices, then find all continuous IDX fragments.
+        all_continuous_fragments = clocktools.find_idx_boundaries(
+                                                np.where(~np.isnan(pupil_radii))[0], 
+                                                drop_single_idx=True)
+        longest_fragment_idx = np.argmax([len(x) for x in all_continuous_fragments])
+        longest_fragment = all_continuous_fragments[longest_fragment_idx]
+        longest_valid_epoch = eye_times[longest_fragment[-1]] - eye_times[longest_fragment[0]]
+
+        ## Filter pupil radius based on filter method
+        filter_table_row = (shared.FilterMethod) & (PupilFilterMethod & key)
+        filtered_pupil_radii = filter_table_row.run_filter_with_renan(signal=pupil_radii, signal_freq=pupil_fps)
+        
+        ## Split center values and filter based on Filter Method defined 3 lines above
+        center_xs = [c[0] if c is not None else np.nan for c in pupil_centers]
+        center_ys = [c[1] if c is not None else np.nan for c in pupil_centers]
+        filtered_center_xs = filter_table_row.run_filter_with_renan(signal=center_xs, signal_freq=pupil_fps)
+        filtered_center_ys = filter_table_row.run_filter_with_renan(signal=center_ys, signal_freq=pupil_fps)
+        filtered_pupil_centers = [[x,y] for x,y in zip(filtered_center_xs,filtered_center_ys)]
+
+        ## Calculate extra statistics
+        mean_radius = np.nanmean(filtered_pupil_radii)
+        radius_95 = np.nanpercentile(filtered_pupil_radii, 95)
+        
+        self.insert1({**key, 'valid_start': valid_start, 'valid_end': valid_end,
+                    'valid_fraction': valid_fraction, 'longest_valid_epoch': longest_valid_epoch,
+                    'mean_radius': mean_radius, 'radius_95': radius_95, 'pupil_sampling_rate': pupil_fps,
+                    'filtered_pupil_radius': filtered_pupil_radii,
+                    'filtered_pupil_center': filtered_pupil_centers})
+
+
+@schema
+class PupilUnitConversionMethod(dj.Lookup):
+    definition = """ # Method to determine millimeters per pixel conversion factor in pupil movies
+    unit_conversion_method_id     : tinyint unsigned    # index for method to determine conversion factor
+    ---
+    conversion_method_description : varchar(256)
+    """
+    contents = [[1, 'Manual'],
+                [2, 'Measure eyelid width using DeepLabCut and convert using assumed universal mouse eyelid width 2.757mm'],]
+    
+
+
+@schema
+class PupilUnitConversion(dj.Computed):
+    definition = """ # Pixel to millimeter conversion factor
+    -> ProcessedPupil
+    -> PupilUnitConversionMethod
+    ---
+    conversion_factor             : float               # (mm/pixel) number of millimeters per pixel
+    """
+    
+    def make(self, key):
+        
+        print(f'Populating PupilUnitConversion for {key}')
+        
+        if key['unit_conversion_method_id'] == 1:
+            print('Skipping manual entry method. If you want to use it uncomment the populate code in this table.\n')
+            #conversion_factor = input('Enter manually calculated conversion factor in mm/pixel:\n')
+            #print('')
+            return
+            
+        elif key['unit_conversion_method_id'] == 2:
+            
+            ## ASSUMED CONSTANTS
+            eyelid_width_in_mm = 2.757    # millimeters
+
+            ## Fetch eyelid points to calculate eyelid widths for each frame
+            leftlid_x, leftlid_y = (FittedPupil.EyePoints & key & 'label="eyelid_left"').fetch1('x','y')
+            rightlid_x, rightlid_y = (FittedPupil.EyePoints & key & 'label="eyelid_right"').fetch1('x','y')
+            eyelid_widths = [np.sqrt((lx-rx)**2 + (ly-ry)**2) for lx,ly,rx,ry in 
+                             zip(leftlid_x, leftlid_y, rightlid_x, rightlid_y)]
+            
+            ## Assume that the true eyelid width is the median
+            eyelid_width_in_px = np.nanmedian(eyelid_widths)
+            
+            ## Define mm/px
+            conversion_factor = eyelid_width_in_mm / eyelid_width_in_px
+            
+            ## Sanity check extrapolated size
+            pupil_source = (PupilFilterMethod & key).fetch('pupil_source')
+            
+            if pupil_source == 'Circle':
+                source_table = FittedPupil.Circle
+            elif pupil_source == 'Ellipse':
+                source_table = FittedPupil.Ellipse
+            
+            radius_type = (PupilFilterMethod & key).fetch1('radius_type')
+            pupil_radii = (source_table & key).fetch(radius_type)
+            max_pupil_diameter_px = 2*np.nanpercentile(pupil_radii,99.9)
+            
+            if max_pupil_diameter_px > eyelid_width_in_px:
+                pupil_diameter_mm = round(max_pupil_diameter_px * conversion_factor, 3)
+                msg = f"Pupil diameter {pupil_diameter_mm}mm exceeds assumed eyelid width {eyelid_width_in_mm}mm."
+                raise PipelineException(msg)
+            
+        else:
+            
+            msg = f"Unit conversion method id {key['period_method_id']} is not supported."
+            raise PipelineException(msg)
+            
+        self.insert1({**key, 'conversion_factor': conversion_factor})
+
+
+@schema
+class PupilPeriodMethod(dj.Lookup):
+    definition = """ # Method to extract periods of dilation/constriction in pupil trace
+    period_method_id              : tinyint unsigned    # index of pupil period method
+    ---
+    period_method_description     : varchar(256)
+    """
+    
+    contents = [[1, 'Peak detection followed by filtering out events < 1sec or with an average speed < 0.02mm/sec. Any event comprised of over 15% NaNs is automatically dropped.'],
+                ]
+    
+
+@schema
+class PupilPeriods(dj.Computed):
+    definition = """ # Scan level statistics on dilations & constrictions
+    -> ProcessedPupil
+    -> PupilPeriodMethod
+    -> PupilUnitConversion
+    ---
+    dilation_freq                 : float               # dilations per second (within valid start/end)
+    constriction_freq             : float               # constrictions per second (within valid start/end)
+    num_pupil_periods             : smallint unsigned   # total number of dilation and constriction periods
+    """
+
+    class DilationConstriction(dj.Part):
+        definition = """ # Single period of dilation or constriction
+        -> PupilPeriods
+        period_idx                : smallint unsigned
+        ---
+        period_onset              : float               # period start time (in seconds)
+        period_offset             : float               # period stop time (in seconds)
+        peak_change_time          : float               # time (in seconds) at which peak change rate occurs
+        period_delta              : float               # overall change in size (in pixels, as a placeholder for now)
+        period_duration           : float               # period duration (in seconds)
+        """
+        
+    def _make_tuples(self, key):
+        
+        print(f'Populating PupilPeriods for {key}')
+
+        if key['period_method_id'] == 1:
+
+            ## DEFINE CONSTANTS
+            min_period_duration = 1      # sec
+            min_dilation_vel = 0.01      # mm/sec
+            min_constriction_vel = 0.01  # mm/sec (Note: This will be made negative in the code below)
+            max_nan_gap_percent = 0.15   # percentage of event made up by NaNs must be below this value
+
+            ## Fetch conversion factor
+            px_to_mm = (PupilUnitConversion & key).fetch1('conversion_factor')
+
+            ## Get timing data
+            pupil_times = (Eye & key).fetch1('eye_time')
+            pupil_fps = 1/np.nanmedian(np.diff(pupil_times))
+
+            ## Calculate peaks and valleys over nan-interpolated radii
+            ## np.diff(np.sign(derivative)) creates an array that's -1 when at a peak and 1 at valleys
+            ## (Apologies in advance for that opaque one-liner)
+            pupil_radii = (ProcessedPupil & key).fetch1('filtered_pupil_radius')
+            nan_filled_pupil_radii = (shared.FilterMethod & 'filter_method="NaN Filler"').run_filter(pupil_radii)
+            derivative_of_radii = np.gradient(nan_filled_pupil_radii, pupil_times)
+            peaks = np.where(np.diff(np.sign(derivative_of_radii)) < 0)[0]
+            valleys = np.where(np.diff(np.sign(derivative_of_radii)) > 0)[0]
+
+            ## Store all events in array to sort later
+            all_events = []
+
+            ## Find all constriction events that are valid
+            for start in peaks:
+
+                end = valleys[np.argmax(valleys > start)]  ## Note: This gives the idx of the first "True" in array
+                if sum(valleys > start) == 0:
+                    end = len(nan_filled_pupil_radii)-1
+
+                event_idx = np.arange(start,end+1)
+                period_duration = pupil_times[end] - pupil_times[start]
+                period_delta = (nan_filled_pupil_radii[end] - nan_filled_pupil_radii[start]) * px_to_mm
+                period_slope = period_delta / period_duration
+                peak_change_time = pupil_times[np.nanargmax(np.abs(derivative_of_radii[start:end]))]
+
+                ## Create key if passes threshold
+                if period_duration > min_period_duration and period_slope < -min_constriction_vel:
+                    if sum(np.isnan(pupil_radii[event_idx])) < len(event_idx)*max_nan_gap_percent:
+                        event_key = {'period_onset': pupil_times[start], 'period_offset': pupil_times[end],
+                                     'period_duration': period_duration, 'period_delta': period_slope,
+                                     'peak_change_time': peak_change_time}
+                        all_events.append(event_key)
+
+            ## Find all dilation events that are valid
+            for start in valleys:
+
+                end = peaks[np.argmax(peaks > start)]  ## Note: This gives the idx of the first "True" in array
+                if sum(peaks > start) == 0:
+                    end = len(nan_filled_pupil_radii)-1
+
+                event_idx = np.arange(start,end+1)
+                period_duration = pupil_times[end] - pupil_times[start]
+                period_delta = (nan_filled_pupil_radii[end] - nan_filled_pupil_radii[start]) * px_to_mm
+                period_slope = period_delta / period_duration
+                peak_change_time = pupil_times[np.nanargmax(np.abs(derivative_of_radii[start:end]))]
+
+                ## Create key if passes threshold
+                if period_duration > min_period_duration and period_slope > min_dilation_vel:
+                    if sum(np.isnan(pupil_radii[event_idx])) < len(event_idx)*max_nan_gap_percent:
+                        event_key = {'period_onset': pupil_times[start], 'period_offset': pupil_times[end],
+                                     'period_duration': period_duration, 'period_delta': period_slope,
+                                     'peak_change_time': peak_change_time}
+                        all_events.append(event_key)
+
+            ## Sort all events before adding index to keys
+            all_event_starts = [e['period_onset'] for e in all_events]
+            event_sorting = np.argsort(all_event_starts)
+            all_events = np.array(all_events)[event_sorting]
+            for n,event in enumerate(all_events):
+                event['period_idx'] = n+1
+
+            ## Calculate statistics for dilations/constrictions
+            dilation_num = len([e for e in all_events if e['period_delta'] > 0])
+            constriction_num = len([e for e in all_events if e['period_delta'] < 0])
+            valid_length = np.nanmax(pupil_times) - np.nanmin(pupil_times)
+            dilation_freq = dilation_num/valid_length
+            constriction_freq = constriction_num/valid_length
+
+            ## Insert data
+            pupil_period_key = {**key, 'dilation_freq': dilation_freq, 'constriction_freq': constriction_freq, 
+                                'num_pupil_periods': len(all_events)}
+            self.insert1(pupil_period_key)
+
+            for event in all_events:
+                self.DilationConstriction.insert1({**key, **event})
+
+        else:
+
+            msg = f"Pupil period method id {key['period_method_id']} not supported."
+            raise PipelineException(msg)
+            
+    def plot_pupil_periods(self, x_stepsize=None, figsize=(100,10)):
+
+        key = self.fetch1('KEY')
+        
+        ## Create figure
+        with plt.style.context('fivethirtyeight'):
+            fig,ax = plt.subplots(1,1,figsize=figsize)
+            pupil_slope_plot_dict = {1.0: 'C2', -1.0: 'C3'}
+
+            ## Get conversion factor for plotting
+            px_to_mm = (PupilUnitConversion & key).fetch('conversion_factor')
+
+            ## Get recording times and determine peaks/valleys
+            pupil_times = (Eye & key).fetch1('eye_time')
+            pupil_radii = (ProcessedPupil & key).fetch1('filtered_pupil_radius')
+            nan_filled_pupil_radii = (shared.FilterMethod & 'filter_method="NaN Filler"').run_filter(pupil_radii)
+            derivative_of_radii = np.gradient(nan_filled_pupil_radii, pupil_times)
+            peaks = np.where(np.diff(np.sign(derivative_of_radii)) < 0)[0]
+            valleys = np.where(np.diff(np.sign(derivative_of_radii)) > 0)[0]
+
+            ## Plot peaks/valleys on top of processed pupil diameter
+            ax.plot(pupil_times, 2 * pupil_radii * px_to_mm, color='black', alpha=0.7, linewidth=2)
+            ax.scatter(pupil_times[peaks], 2*pupil_radii[peaks]*px_to_mm, color='C0', marker='o', zorder=10)
+            ax.scatter(pupil_times[valleys], 2*pupil_radii[valleys]*px_to_mm, color='C1', marker='o', zorder=10)
+
+
+            ## Fetch pupil dilation and constriction data
+            all_onsets, all_offsets, all_deltas = (PupilPeriods.DilationConstriction & key).fetch('period_onset', 'period_offset', 'period_delta')
+            for onset,offset,delta in zip(all_onsets, all_offsets, all_deltas):
+                sign = np.sign(delta)
+                ax.axvspan(onset, offset, color=pupil_slope_plot_dict[sign], alpha=0.3)
+
+            ## Clean Plot
+            title = f"ID {key['animal_id']} Session {key['session']} Scan {key['scan_idx']}"
+            ax.set_title(title, fontsize=50)
+            ax.set_ylabel('Pupil Diameter (mm)', fontsize=20)
+            ax.set_xlabel('Scan Time (sec)', fontsize=20)
+            if x_stepsize is not None:
+                x_start, x_end = ax.get_xlim()
+                ax.xaxis.set_ticks(np.arange(round(x_start,0), round(x_end,0), x_stepsize))
+
+        return fig
 
 
 # class PlotFitting(object):

--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -1,11 +1,13 @@
 import datajoint as dj
 from datajoint.jobs import key_hash
 import numpy as np
+import matplotlib.pyplot as plt
 from commons import lab
+from pipeline import shared
 import os
 
 from . import experiment, notify
-from .utils import h5
+from .utils import h5, clocktools
 
 
 schema = dj.schema('pipeline_treadmill', locals())
@@ -96,3 +98,251 @@ class Treadmill(dj.Computed):
         msg = 'treadmill velocity for {animal_id}-{session}-{scan_idx}'.format(**key)
         slack_user = notify.SlackUser() & (experiment.Session() & key)
         slack_user.notify(file=img_filename, file_title=msg)
+        
+        
+@schema
+class RunningMethod(dj.Lookup):
+    definition = """ # Method to extract periods of running
+    running_method_id             : tinyint unsigned    # index for running classification method
+    ---
+    run_method_description        : varchar(256)        # description of running classification method
+    """
+    contents = [[1, 'Threshold based method requiring run times > 1sec and concatenating run times < 1sec apart'],
+                ]
+ 
+    
+@schema
+class Running(dj.Computed):
+    definition = """ # Scan level statistics about running periods
+    -> Treadmill
+    -> shared.FilterMethod
+    -> RunningMethod
+    ---
+    processed_treadmill           : longblob            # filtered version of treadmill speed
+    total_run_duration            : float               # (sec) total amount of time spent running
+    percent_running               : float               # (percent) percent of time spent running
+    mean_run_velocity             : float               # (cm/sec) mean velocity for entire treadmill trace
+    mean_run_speed                : float               # (cm/sec) mean speed for entire treadmill trace
+    max_run_speed                 : float               # (cm/sec) maximum speed during recording
+    num_run_periods               : smallint unsigned   # number of running periods
+    """
+   
+    class Period(dj.Part):
+        definition = """ # Single running event detected 
+        -> Running
+        run_idx                   : smallint unsigned   # running event id
+        ---
+        run_onset                 : float               # (sec) onset time on behavior clock
+        run_offset                : float               # (sec) offset time on behavior clock
+        run_duration              : float               # (sec) duration of running period
+        mean_velocity             : float               # (cm/sec) 
+        mean_speed                : float               # (cm/sec) 
+        max_speed                 : float               # (cm/sec)
+        """
+
+    def make(self, key):
+        
+        print(f'Populating Running for {key}')
+        
+        ## Get treadmill info
+        treadmill_times, treadmill_velocity = (Treadmill & key).fetch1('treadmill_time', 'treadmill_vel')
+        treadmill_speed = np.abs(treadmill_velocity)
+        treadmill_fps = 1/np.nanmedian(np.diff(treadmill_times))
+        
+        ## Filter treadmill velocity and speed
+        ## NOTE: Treadmill speed is NOT absolute value to filtered velocity. Filtering is applied after np.abs.
+        my_filter = (shared.FilterMethod & key).run_filter_with_renan
+        filt_treadmill_velocity = my_filter(treadmill_velocity, treadmill_fps)
+        filt_treadmill_speed = my_filter(treadmill_speed, treadmill_fps)
+        
+        ## Run running detection method
+        if key['running_method_id'] == 1:
+
+            ## CONSTANTS
+            run_speed_threshold = 1 ## cm/sec
+            maximum_time_gap = 3    ## sec
+            minimum_run_length = 1  ## sec
+            
+            running_indices = np.where(filt_treadmill_speed > run_speed_threshold)[0]
+            combined_running_periods = self._combine_running_periods(running_indices, treadmill_times, maximum_time_gap)
+            finalized_running_periods = self._remove_short_running_periods(combined_running_periods, treadmill_times, minimum_run_length)
+
+        else:
+            
+            msg = f"Pupil period method id {key['period_method_id']} not supported."
+            raise PipelineException(msg)
+
+        ## Calculate statistics
+        mean_run_velocity = np.nanmean(filt_treadmill_speed)
+        mean_run_speed = np.nanmean(treadmill_speed)
+        max_run_speed = np.nanmax(treadmill_speed)
+        num_run_periods = len(finalized_running_periods)
+        
+        ## Loop through running periods
+        running_period_keys = []
+        total_run_duration = 0
+        for n,running_period in enumerate(finalized_running_periods):
+            run_period_key = key.copy()
+            run_period_key['run_idx'] = n+1
+            run_period_key['run_onset'] = treadmill_times[running_period[0]]
+            run_period_key['run_offset'] = treadmill_times[running_period[-1]]
+            run_period_key['run_duration'] = run_period_key['run_offset'] - run_period_key['run_onset']
+            run_period_key['mean_velocity'] = np.nanmean(filt_treadmill_velocity[running_period])
+            run_period_key['mean_speed'] = np.nanmean(filt_treadmill_speed[running_period])
+            run_period_key['max_speed'] = np.nanmax(filt_treadmill_speed[running_period])
+            total_run_duration += run_period_key['run_duration']
+            running_period_keys.append(run_period_key)
+            
+        ## Calculate total running statistics
+        treadmill_duration = np.nanmax(treadmill_times) - np.nanmin(treadmill_times)
+        percent_running = total_run_duration / treadmill_duration * 100
+        
+        ## Insert key values 
+        running_key = {**key, 'processed_treadmill': filt_treadmill_speed, 'total_run_duration': total_run_duration, 
+                       'percent_running': percent_running, 'mean_run_velocity': mean_run_velocity,
+                       'mean_run_speed': mean_run_speed, 'max_run_speed': max_run_speed, 
+                       'num_run_periods': num_run_periods}
+        self.insert1(running_key)
+        self.Period.insert(running_period_keys)
+
+        
+    def _combine_running_periods(self, running_indices, tread_times, maximum_time_gap):
+
+        """
+        Given a flattened 1d array/list of indices, combines defined indices and indices between them if their gap
+        is less than maximum_time_gap.
+
+            Parameters:
+                running_indices: Flattened list or numpy array of indices corresponding to detected running times
+                tread_times: List or numpy array of times each recording on the treadmill was taken
+                maximum_time_gap: Numeric value of maximum gap before running periods should not be combined. 
+                                  Value is written in seconds.
+
+            Returns:
+                combined_running_fragments: List of lists of continuous incrementing indices corresponding to
+                                            single periods of running.
+        """
+
+        ## Splits list of indices into a list of lists. Each sublist contains indices which continuously increase by 1.
+        ## This function also drops sublists which only contain a single idx.
+        running_fragments = clocktools.find_idx_boundaries(running_indices, drop_single_idx=True)
+
+        ## If we have two or more fragments, test if any should be combined
+        if len(running_fragments) > 1:
+
+            ## Basic idea: Have a temporary start index. Loop through all lists of indices. Whenever there is a list
+            ## start idx which is more than maximum_time_gap seconds away from the previous list end, insert a combined 
+            ## list of indices between temporary start index and last index before that gap. Then update the temporary
+            ## start to be the first index after the detected gap. This loop has one blind spot, which is the final list. 
+            ## That is checked manually afterwards.
+
+            combined_running_fragments = []
+            temp_start_idx = running_fragments[0][0]
+
+            ## Fragment1 is the current fragment, while Fragment2 is the fragment directly afterwards. Loop stops one 
+            ## fragment before the end of the list running_fragments.
+            for fragment1, fragment2 in zip(running_fragments[:-1], running_fragments[1:]):
+
+                fragment1_end_time = tread_times[fragment1[-1]]
+                fragment2_start_time = tread_times[fragment2[0]]
+                gap_duration = fragment2_start_time - fragment1_end_time
+
+                if gap_duration > maximum_time_gap:
+                    temp_end_idx = fragment1[-1]
+                    combined_fragment = np.arange(temp_start_idx, temp_end_idx+1) ## +1 so we include final idx
+                    combined_running_fragments.append(combined_fragment)
+                    temp_start_idx = fragment2[0]
+
+            ## Run check for last entry in running_fragments
+            final_gap_start = tread_times[running_fragments[-2][-1]]
+            final_gap_end = tread_times[running_fragments[-1][0]]
+            final_gap_duration = final_gap_end - final_gap_start
+
+            ## If the last entry should be combined, rewrite last array in combined_running_fragments
+            if final_gap_duration <= maximum_time_gap:
+                temp_end_idx = running_fragments[-1][-1]
+                final_combined_fragment = np.arange(temp_start_idx, temp_end_idx+1)  ## +1 so we include final idx
+                combined_running_fragments.append(final_combined_fragment)
+
+            ## Append last running period if it doens't need to be combined
+            else:
+                combined_running_fragments.append(running_fragments[-1])
+
+        else:
+
+            ## If we only have 0 to 1 entries, nothing to combine
+            combined_running_fragments = running_fragments
+
+        return combined_running_fragments
+
+
+    def _remove_short_running_periods(self, running_fragments, tread_times, minimum_run_length):
+        """
+        Given a list of lists of indices for running periods, removes any running period which is less than the
+        defined minimum run length.
+
+            Parameters:
+                running_fragments: List/np.array of lists/np.arrays. Each sublist must correspond to the indices for
+                                   a single period of running.
+                tread_times: List or np.array of times each recording on the treadmill was taken
+                minimum_run_legnth: Numeric value. The duration of a running period must be equal to or greater than
+                                    this value to be returned. Units are seconds.
+
+            Returns:
+                long_running_fragments: List of lists of running fragments with a duration equal or above
+                                        minimum_run_length. Each sublist contains indices correspond to said
+                                        running period.
+
+        """
+
+        long_running_fragments = []
+        for running_fragment in running_fragments:
+
+            run_start = tread_times[running_fragment[0]]
+            run_end = tread_times[running_fragment[-1]]
+            run_duration = run_end - run_start
+
+            if run_duration >= minimum_run_length:
+                long_running_fragments.append(running_fragment)
+
+        return long_running_fragments
+    
+    
+    def plot_running_periods(self, threshold=None, use_raw=False, x_stepsize=None, figsize=(100,10)):
+
+        key = self.fetch1('KEY')
+        
+        ## Fetch data
+        onsets, offsets = (Running.Period & key).fetch('run_onset', 'run_offset')
+        tread_times = (Treadmill & key).fetch1('treadmill_time')
+        if use_raw:
+            tread_vel = (Treadmill & key).fetch1('treadmill_vel')
+            tread_speed = np.abs(tread_vel)
+        else:
+            tread_speed = (Running & key).fetch1('processed_treadmill')
+
+        ## Create figure
+        with plt.style.context('fivethirtyeight'):
+            fig,ax = plt.subplots(1,1,figsize=figsize)
+
+            ## Plot treadmill speed
+            ax.plot(tread_times, tread_speed, color='black', alpha=0.7, linewidth=2)
+
+            ## Plot threshold line if given
+            if threshold is not None:
+                ax.axhline(threshold, color='C0', alpha=0.7, linewidth=2)
+
+            ## Plot detected events
+            for onset,offset in zip(onsets, offsets):
+                ax.axvspan(onset, offset, color='C1', alpha=0.3)
+
+            ## Clean Plot
+            title = f"ID {key['animal_id']} Session {key['session']} Scan {key['scan_idx']}"
+            ax.set_title(title, fontsize=50)
+            ax.set_ylabel('Treadmill Speed (cm/sec)', fontsize=20)
+            ax.set_xlabel('Scan Time (sec)', fontsize=20)
+            if x_stepsize is not None:
+                x_start, x_end = ax.get_xlim()
+                ax.xaxis.set_ticks(np.arange(round(x_start,0), round(x_end,0), x_stepsize))
+
+        return fig

--- a/python/pipeline/utils/clocktools.py
+++ b/python/pipeline/utils/clocktools.py
@@ -1,0 +1,996 @@
+import numbers
+import numpy as np
+import datajoint as dj
+from scipy import interpolate
+from stimulus import stimulus
+from pipeline.exceptions import PipelineException
+from pipeline import treadmill, fuse, shared, odor
+
+pupil = dj.create_virtual_module("pipeline_eye", "pipeline_eye")
+
+
+def find_idx_boundaries(indices, drop_single_idx=False):
+    """
+    Given a flatten list/array of indices, break list into a list of lists of indices incrementing by 1
+
+        Example:
+            >>>find_idx_boundaries([1,2,3,4,501,502,503,504])
+               return value: [[1,2,3,4],[501,502,503,504]]
+
+        Parameters:
+            indices: Flattened list or numpy array of indices to break apart into sublists
+            drop_single_idx: Boolean which sets if single indices not part of any sublist
+                             should be dropped or raise an error upon detection.
+
+        Returns:
+            events: List of lists of indices that are incrementing by 1
+
+    """
+
+    ## Since list slicing counts up to but not including ends, we need to add 1 to all detected end locations
+    ends = np.where(np.diff(indices) > 1)[0] + 1
+
+    ## Starts and ends will equal each other since list slicing includes start values, but start needs 0 appended
+    starts = np.copy(ends)
+    if len(starts) == 0 or starts[0] != 0:
+        starts = np.insert(starts, 0, 0)
+
+    ## np.diff returns an array one smaller than the indices list, so we need to add the last idx to the ends
+    if len(ends) == 0 or ends[-1] != len(indices):
+        ends = np.insert(ends, len(ends), len(indices))
+
+    ## Loop through all continuous idx start & end to see if any are too small (length = 1)
+    events = []
+    for start, end in zip(starts, ends):
+        if end - start < 2:
+            if not drop_single_idx:
+                raise PipelineException(f"Disconnected index found at index {start}")
+        else:
+            events.append(indices[start:end])
+
+    return events
+
+
+def find_time_boundaries(indices, times, drop_single_idx=False):
+    """
+    Given a flatten list/array of indices and timings, return the start & stop times for all idx clusters
+    incrementing by 1. Start/stop times are taken to be non-NaN min/max times during the idx fragment.
+
+        Example:
+            >>>find_time_boundaries(indices=[1,2,3,501,502,503],times=[0.1,0.2,0.3,0.4,0.5,0.6])
+               return value: [[0.1,0.3], [0.4,0.6]]
+
+        Parameters:
+            indices: Flattened list or numpy array of indices to break apart into incrementing fragments
+            times: Flattened list or numpy array of times of recording. Can either be the same size as
+                   the list of indices (only the times corresponding to those indices) or can be the
+                   full list of all times recordings happened. If full list, indices are assumed to index
+                   their own recording time in the times array/list.
+            drop_single_idx: Boolean which sets if single indices not part of any sublist
+                             should be dropped or raise an error upon detection.
+
+        Returns:
+            events: List of lists of start & stop times for each incrementing by 1 idx fragments
+
+    """
+
+    ## If times are not the same size as indices, assume these times are for all recordings
+    ## and the recording time for IDX NUM is times[NUM] (ie. idx 5 was recorded at times[5])
+    if len(times) != len(indices):
+        times = np.array(times)[np.array(indices)]
+
+    ## Since list slicing counts up to but not including ends, we need to add 1 to all detected end locations
+    ends = np.where(np.diff(indices) > 1)[0] + 1
+
+    ## Starts and ends will equal each other since list slicing includes start values, but start needs 0 appended
+    starts = np.copy(ends)
+    if len(starts) == 0 or starts[0] != 0:
+        starts = np.insert(starts, 0, 0)
+
+    ## np.diff returns an array one smaller than the indices list, so we need to add the last idx to the ends
+    if len(ends) == 0 or ends[-1] != len(indices):
+        ends = np.insert(ends, len(ends), len(indices))
+
+    ## Loop through all continuous idx start & end to see if any are too small (length = 1)
+    time_boundaries = []
+    for start, end in zip(starts, ends):
+        if end - start < 2:
+            if not drop_single_idx:
+                raise PipelineException(f"Disconnected index found at index {start}")
+        else:
+            bounds = [np.nanmin(times[start:end]), np.nanmax(times[start:end])]
+            time_boundaries.append(bounds)
+
+    return time_boundaries
+
+
+def fetch_timing_data(
+    scan_key: dict,
+    source_type: str,
+    target_type: str,
+    debug: bool = True,
+):
+
+    ##
+    ## Set pipe, error check scan_key, and fetch field offset
+    ##
+
+    ## Define the pipe (meso/reso) to use
+    if len(fuse.MotionCorrection & scan_key) == 0:
+        msg = f"scan_key {scan_key} not found in fuse.MotionCorrection."
+        raise PipelineException(msg)
+    pipe = (fuse.MotionCorrection & scan_key).module
+
+    ## Make strings lowercase and process indices
+    source_type = source_type.lower()
+    target_type = target_type.lower()
+
+    ## Set default values for later processing
+    field_offset = 0
+    slice_num = 1
+    ms_delay = 0
+
+    ## Determine if source or target type requires extra scan info
+    scan_types = (
+        "fluorescence-stimulus",
+        "fluorescence-behavior",
+        "deconvolution-stimulus",
+        "deconvolution-behavior",
+    )
+    if source_type in scan_types or target_type in scan_types:
+
+        ## Check scan_key defines a unique scan
+        if len(pipe.ScanInfo & scan_key) != 1:
+            msg = (
+                f"scan_key {scan_key} does not define a unique scan. "
+                f"Matching scans found: {len(fuse.MotionCorrection & scan_key)}"
+            )
+            raise PipelineException(msg)
+
+        ## Check a single field is defined by scan_key
+        if len(pipe.ScanInfo.Field & scan_key) != 1:
+            msg = (
+                f"scan_key {scan_key} must specify a single field when source or target type is set "
+                f"to 'scan'. Matching fields found: {len(pipe.ScanInfo.Field & scan_key)}"
+            )
+            raise PipelineException(msg)
+
+        ## Determine field offset to slice times later on and set ms_delay to field average
+        scan_restriction = (pipe.ScanInfo & scan_key).fetch("KEY")
+        all_z = np.unique(
+            (pipe.ScanInfo.Field & scan_restriction).fetch("z", order_by="field ASC")
+        )
+        slice_num = len(all_z)
+        field_z = (pipe.ScanInfo.Field & scan_key).fetch1("z")
+        field_offset = np.where(all_z == field_z)[0][0]
+        if debug:
+            print(f"Field offset found as {field_offset} for depths 0-{len(all_z)}")
+
+        field_delay_im = (pipe.ScanInfo.Field & scan_key).fetch1("delay_image")
+        average_field_delay = np.mean(field_delay_im)
+        ms_delay = average_field_delay
+        if debug:
+            print(
+                f"Average field delay found to be {round(ms_delay,4)}ms. This will be used unless a unit is specified in the key."
+            )
+
+        ## If included, add unit offset
+        if "unit_id" in scan_key or "mask_id" in scan_key:
+            if len(pipe.ScanSet.Unit & scan_key) > 0:
+                unit_key = (pipe.ScanSet.Unit & scan_key).fetch1()
+                ms_delay = (pipe.ScanSet.UnitInfo & unit_key).fetch1("ms_delay")
+                if debug:
+                    print(
+                        f"Unit found with delay of {round(ms_delay,4)}ms. Delay added to relevant times."
+                    )
+            else:
+                if debug:
+                    print(
+                        f"Warning: ScanSet.Unit is not populated for the given key! Using field offset minimum instead."
+                    )
+
+    ##
+    ## Fetch source and target sync data
+    ##
+
+    ## Define a lookup for data sources. Key values are in (data_table, column_name) tuples.
+    data_source_lookup = {
+        "fluorescence-stimulus": (stimulus.Sync, "frame_times"),
+        "deconvolution-stimulus": (stimulus.Sync, "frame_times"),
+        "fluorescence-behavior": (stimulus.BehaviorSync, "frame_times"),
+        "deconvolution-behavior": (stimulus.BehaviorSync, "frame_times"),
+        "treadmill": (treadmill.Treadmill, "treadmill_time"),
+        "pupil": (pupil.Eye, "eye_time"),
+        "respiration": (odor.Respiration * odor.MesoMatch, "times"),
+    }
+
+    ## Error check inputs
+    if source_type not in data_source_lookup or target_type not in data_source_lookup:
+        msg = (
+            f"source and target type combination '{source_type}' and '{target_type}' not supported. "
+            f"Valid values are 'scan-behavior', 'scan-stimulus', 'treadmill', 'respiration' or 'pupil'."
+        )
+        raise PipelineException(msg)
+
+    ## Fetch source and target times using lookup dictionary
+    source_table, source_column = data_source_lookup[source_type]
+    source_times = (source_table & scan_key).fetch1(source_column).squeeze()
+
+    target_table, target_column = data_source_lookup[target_type]
+    target_times = (target_table & scan_key).fetch1(target_column).squeeze()
+
+    ##
+    ## Timing corrections
+    ##
+
+    ## Slice times if on ScanImage clock and add delay (scan_types defined near top)
+    if source_type in scan_types:
+        source_times = source_times[field_offset::slice_num] + ms_delay
+    if target_type in scan_types:
+        target_times = target_times[field_offset::slice_num] + ms_delay
+
+    ##
+    ## Interpolate into different clock if necessary
+    ##
+
+    clock_type_lookup = {
+        "fluorescence-stimulus": "stimulus",
+        "deconvolution-stimulus": "stimulus",
+        "fluorescence-behavior": "behavior",
+        "deconvolution-behavior": "behavior",
+        "pupil": "behavior",
+        "processed-pupil": "behavior",
+        "treadmill": "behavior",
+        "processed-treadmill": "behavior",
+        "respiration": "odor",
+    }
+
+    sync_conversion_lookup = {
+        "stimulus": stimulus.Sync,
+        "behavior": stimulus.BehaviorSync,
+        "odor": odor.OdorSync * odor.MesoMatch,
+    }
+
+    source_clock_type = clock_type_lookup[source_type]
+    target_clock_type = clock_type_lookup[target_type]
+
+    if source_clock_type != target_clock_type:
+
+        interp_source_table = sync_conversion_lookup[source_clock_type]
+        interp_target_table = sync_conversion_lookup[target_clock_type]
+
+        interp_source = (interp_source_table & scan_key).fetch1("frame_times").squeeze()
+        interp_target = (interp_target_table & scan_key).fetch1("frame_times").squeeze()
+
+        source2target_interp = interpolate.interp1d(
+            interp_source, interp_target, fill_value="extrapolate"
+        )
+        source_times = source2target_interp(source_times)
+
+    return source_times, target_times
+
+
+def interpolate_signal_data(
+    scan_key: dict,
+    source_type: str,
+    target_type: str,
+    source_times,
+    target_times,
+    debug: bool = True,
+):
+
+    ## Pre-format source_type
+    source_type = source_type.lower()
+
+    ## Define the pipe (meso/reso) to use
+    if len(fuse.MotionCorrection & scan_key) == 0:
+        msg = f"scan_key {scan_key} not found in fuse.MotionCorrection."
+        raise PipelineException(msg)
+    pipe = (fuse.MotionCorrection & scan_key).module
+
+    ## Run helpful error checking
+    if source_type == "pupil":
+        tracking_method_num = len(
+            dj.U("tracking_method") & (pupil.FittedPupil & scan_key)
+        )
+        if tracking_method_num > 1:
+            msg = (
+                "More than one pupil tracking method found for entered scan. "
+                "Specify tracking_method in scan key (tracking_method=2 for DeepLabCut)."
+            )
+            raise PipelineException(msg)
+
+    ## Fetch required signal
+    ## Note: Pupil requires .fetch() while other signals require .fetch1().
+    ##       It is easier to make an if-elif-else structure than a lookup dictionary in this case.
+    if source_type in ("fluorescence-stimulus", "fluorescence-behavior"):
+        source_signal = (pipe.Fluorescence.Trace & scan_key).fetch1("trace")
+    if source_type in ("deconvolution-stimulus", "deconvolution-behavior"):
+        unit_key = (pipe.ScanSet.Unit & scan_key).fetch1()
+        source_signal = (pipe.Activity.Trace & unit_key).fetch1("trace")
+    if source_type == "pupil":
+        source_signal = (pupil.FittedPupil.Circle & scan_key).fetch("radius")
+    if source_type == "treadmill":
+        source_signal = (treadmill.Treadmill & scan_key).fetch1("treadmill_vel")
+
+    ## Calculate FPS to determine if lowpass filtering is needed
+    source_fps = 1 / np.nanmedian(np.diff(source_times))
+    target_fps = 1 / np.nanmedian(np.diff(target_times))
+
+    ## Fill NaNs to prevent interpolation errors, but store NaNs for later to add back in after interpolating
+    target_replace_nans = None  # Use this as a switch to refill things later
+    if sum(np.isnan(source_signal)) > 0:
+        source_nan_indices = np.isnan(source_signal)
+        time_nan_indices = np.isnan(source_times)
+        source_replace_nans = np.logical_and(source_nan_indices, ~time_nan_indices)
+        if sum(source_replace_nans) > 0:
+            target_replace_nans = convert_clocks_idx_to_idx(
+                scan_key,
+                np.where(source_replace_nans)[0],
+                source_type,
+                target_type,
+                debug=False,
+            )
+        nan_filler_func = (
+            shared.FilterMethod & {"filter_method": "NaN Filler"}
+        ).run_filter
+        source_signal = nan_filler_func(source_signal)
+        if debug:
+            biggest_time_gap = np.nanmax(
+                np.diff(source_times[np.where(~source_replace_nans)[0]])
+            )
+            msg = (
+                f"Found NaNs in {sum(source_nan_indices)} locations, which corresponds to "
+                f"{round(100*sum(source_nan_indices)/len(source_signal),2)}% of total signal. "
+                f"Largest NaN gap found: {round(biggest_time_gap, 2)} seconds."
+            )
+            print(msg)
+
+    ## Lowpass signal if needed
+    if target_fps < source_fps:
+        if debug:
+            msg = (
+                f"Source FPS of {round(source_fps,2)} is greater than target FPS {round(target_fps,2)}. "
+                f"Hamming lowpass filtering source signal before interpolation"
+            )
+            print(msg)
+        source_signal = shared.FilterMethod._lowpass_hamming(
+            signal=source_signal, signal_freq=source_fps, lowpass_freq=target_fps
+        )
+
+    ## Timing and recording array lengths can differ slightly if recording was stopped mid-scan. Timings for
+    ## the next X depths would be recorded, but fluorescence values would be dropped if all depths were not
+    ## recorded. This would mean timings difference shouldn't be more than the number of depths of the scan.
+    if len(source_times) < len(source_signal):
+        msg = (
+            f"More recording values than source time values exist! This should not be possible.\n"
+            f"Source time length: {len(source_times)}\n"
+            f"Source signal length: {len(source_signal)}"
+        )
+        raise PipelineException(msg)
+
+    elif len(source_times) > len(source_signal):
+
+        scan_res = pipe.ScanInfo.proj() & scan_key  ## To make sure we select all fields
+        z_plane_num = len(dj.U("z") & (pipe.ScanInfo.Field & scan_res))
+        if (len(source_times) - len(source_signal)) > z_plane_num:
+            msg = (
+                f"Extra timing values exceeds reasonable error bounds. "
+                f"Error length of {len(source_times) - len(source_signal)} with only {z_plane_num} z-planes."
+            )
+            raise PipelineException(msg)
+
+        else:
+            
+            shorter_length = np.min((len(source_times), len(source_signal)))
+            source_times = source_times[:shorter_length]
+            source_signal = source_signal[:shorter_length]
+            if debug:
+                length_diff = np.abs(len(source_times) - len(source_signal))
+                msg = (
+                    f"Source times and source signal show length mismatch within acceptable error."
+                    f"Difference of {length_diff} within acceptable bounds of {z_plane_num} z-planes."
+                )
+                print(msg)
+
+    ## Interpolating source signal into target timings
+    signal_interp = interpolate.interp1d(
+        source_times, source_signal, bounds_error=False
+    )
+    interpolated_signal = signal_interp(target_times)
+    if target_replace_nans is not None:
+        for target_nan_idx in target_replace_nans:
+            interpolated_signal[target_nan_idx] = np.nan
+
+    return interpolated_signal
+
+
+def convert_clocks_idx_to_idx(
+    scan_key: dict,
+    indices,
+    source_type: str,
+    target_type: str,
+    return_interpolate: bool = False,
+    drop_single_idx: bool = True,
+    debug: bool = True,
+):
+    """
+    Converts indices of interest on one type of clock/recording to a different one to be used for slicing or processing.
+
+        Parameters:
+
+                scan_key: A dictionary specifying a single scan and/or field. A single field must be defined if requesting
+                          a source or target from ScanImage. If key specifies a single unit, unit delay will be added to
+                          all timepoints recorded. Single units can be specified via unique mask_id + field or via unit_id.
+                          If only field is specified, average field delay will be added.
+
+                indices: List/array of indices to convert or a boolean array with True values at indices of interest.
+                         NOTE: Set to None to use the entire source signal length.
+                         Indices can be discontinuous fragments (something like 20 indices around a several spikes)
+                         and the function will return of list of lists, each containings the corresponding target_idx
+                         fragments.
+                         ex. [25,26,27..,29,503,504...] OR [False False ... True True True False...] OR None
+
+                source_type: A string specifying what indices you want to convert from. Fluorescence and deconvolution
+                             have a dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options: 
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                target_type: A string specifying what indices to convert into. Fluorescence and deconvolution have a 
+                             dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options: 
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                return_interpolate: Boolean with the following behavior
+                                     - True: Interpolate source signal onto target clock, return interpolated signal
+                                             at indices instead of target indices
+                                             NOTE: NaNs in source signal are linearly interpolated over and then
+                                                   filled back in after interpolation onto target indices.
+                                     - False: Return corresponding indices for target
+
+                drop_single_idx: Boolean with the following behavior
+                                     - True: Drop any signal fragments which would create a signal of length 1.
+                                     - False: Raise an error and stop if any list of indices leads to a signal
+                                              of length 1.
+                                    ex. Source IDX [1,2,...,300] on a 500HZ recording will only correspond to
+                                        target IDX [1] if target is recorded at 1Hz.
+
+                debug: Set function to print helpful debug text while running
+
+
+        Returns:
+
+                requested_array: Numpy array of corresponding indices in target type or interpolated source signal 
+                                 during target indices.
+                                 
+        Warnings:
+        
+                * NaN refilling for source signal will only refill values if NaNs stretch for multiple indices on 
+                  target clock
+                  
+                * Recording points where the time value is NaN are dropped from analysis/processing
+    """
+
+    ##
+    ## Fetch source and target times, along with converting between Stimulus or Behavior clock if needed
+    ##
+
+    source_times, target_times = fetch_timing_data(
+        scan_key, source_type, target_type, debug
+    )
+
+    ##
+    ## Convert indices to a list of numbers if argument equals None or a Boolean mask
+    ##
+
+    if indices is None:
+        indices = np.arange(len(source_times))
+    elif type(indices[0]) == bool:
+        indices = np.where(indices)[0]
+    else:
+        ## Check for duplicates if manually entered
+        if len(np.unique(indices)) != len(indices):
+            msg = (
+                f"Duplicate entries found for provided indice array! "
+                f"Try to fix the error or use np.unique() on indices array."
+            )
+            raise PipelineException(msg)
+
+    ##
+    ## Convert source indices to time boundaries, then convert time boundaries into target indices
+    ##
+
+    ## Convert indices into start/end times for each continuous fragment (incrementing by 1)
+    time_boundaries = find_time_boundaries(indices, source_times, drop_single_idx)
+    target_indices = []
+    single_idx_count = 0
+
+    ## Loop through start & end times and create list of indices corresponding to that block of time
+    for [start, end] in time_boundaries:
+        target_idx = np.where(
+            np.logical_and(target_times >= start, target_times <= end)
+        )[0]
+        if len(target_idx) < 2:
+            if drop_single_idx:
+                single_idx_count += 1
+            else:
+                msg = (
+                    f"Event of length {len(target_idx)} found. "
+                    f"Set drop_single_idx to True to suppress these errors."
+                )
+                raise PipelineException(msg)
+        else:
+            target_indices.append(target_idx)
+
+    if debug:
+        print(f"Indices converted. {single_idx_count} events of length 0 or 1 dropped.")
+
+    ##
+    ## Interpolate related signal if requested, else just return the target_indices found.
+    ##
+
+    if return_interpolate:
+
+        ## Create full interpolated signal
+        interpolated_signal = interpolate_signal_data(
+            scan_key, source_type, target_type, source_times, target_times, debug=debug
+        )
+
+        ## Split indices given into fragments based on which ones are continuous (incrementing by 1)
+        source_signal_fragments = []
+        for idx_fragment in target_indices:
+            source_signal_fragments.append(interpolated_signal[idx_fragment])
+
+        ## If full signal is converted, remove wrapping list
+        if len(source_signal_fragments) == 1:
+            source_signal_fragments = source_signal_fragments[0]
+
+        return source_signal_fragments
+
+    else:
+
+        return target_indices
+    
+
+def convert_clocks_idx_to_time(
+    scan_key: dict,
+    indices,
+    source_type: str,
+    target_type: str,
+    return_interpolate: bool = False,
+    drop_single_idx: bool = True,
+    debug: bool = True,
+):
+    """
+    Converts indices of interest on one type of clock/recording to times on a target clock/recording
+
+        Parameters:
+
+                scan_key: A dictionary specifying a single scan and/or field. A single field must be defined if requesting
+                          a source or target from ScanImage. If key specifies a single unit, unit delay will be added to
+                          all timepoints recorded. Single units can be specified via unique mask_id + field or via unit_id.
+                          If only field is specified, average field delay will be added.
+
+                indices: List/array of indices to convert or a boolean array with True values at indices of interest.
+                         NOTE: Set to None to use the entire source signal length.
+                         Indices can be discontinuous fragments (something like 20 indices around a several spikes)
+                         and the function will return of list of lists, each containings the corresponding target_idx
+                         fragments.
+                         ex. [25,26,27..,29,503,504...] OR [False False ... True True True False...] OR None
+
+                source_type: A string specifying what indices you want to convert from. Fluorescence and deconvolution
+                             have a dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                target_type: A string specifying what times to convert into. Fluorescence and deconvolution have a
+                             dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                return_interpolate: Boolean with the following behavior
+                                     - True: Interpolate source signal onto target clock, return interpolated signal
+                                             at indices instead of target indices
+                                             NOTE: NaNs in source signal are linearly interpolated over and then
+                                                   filled back in after interpolation onto target times.
+                                     - False: Return corresponding times for target
+
+                drop_single_idx: Boolean with the following behavior
+                                     - True: Drop any signal fragments which would create a signal of length 1.
+                                     - False: Raise an error and stop if any list of indices leads to a signal
+                                              of length 1.
+                                    ex. Source IDX [1,2,...,300] on a 500HZ recording will only correspond to
+                                        target IDX [1] if target is recorded at 1Hz.
+
+                debug: Set function to print helpful debug text while running
+
+
+        Returns:
+
+                requested_array: Numpy array of corresponding times in target type recording or interpolated
+                                 source signal during target times.
+
+        Warnings:
+
+                * NaN refilling for source signal will only refill values if NaNs stretch for multiple indices on
+                  target clock
+
+                * Recording points where the time value is NaN are dropped from analysis/processing
+    """
+
+    ##
+    ## Fetch source and target times, along with converting between Stimulus or Behavior clock if needed
+    ##
+
+    source_times, target_times = fetch_timing_data(
+        scan_key, source_type, target_type, debug
+    )
+
+    ##
+    ## Convert indices to a list of numbers if argument equals None or a Boolean mask
+    ##
+
+    if indices is None:
+        indices = np.arange(len(source_times))
+    elif type(indices[0]) == bool:
+        indices = np.where(indices)[0]
+    else:
+        ## Check for duplicates if manually entered
+        if len(np.unique(indices)) != len(indices):
+            msg = (
+                f"Duplicate entries found for provided indice array! "
+                f"Try to fix the error or use np.unique() on indices array."
+            )
+            raise PipelineException(msg)
+
+    ##
+    ## Convert source indices to time boundaries, then convert time boundaries into target indices
+    ##
+
+    ## Convert indices into start/end times for each continuous fragment (incrementing by 1)
+    time_boundaries = find_time_boundaries(indices, source_times, drop_single_idx)
+    target_indices = []
+    single_idx_count = 0
+
+    ## Loop through start & end times and create list of indices corresponding to that block of time
+    for [start, end] in time_boundaries:
+        target_idx = np.where(
+            np.logical_and(target_times >= start, target_times <= end)
+        )[0]
+        if len(target_idx) < 2:
+            if drop_single_idx:
+                single_idx_count += 1
+            else:
+                msg = (
+                    f"Event of length {len(target_idx)} found. "
+                    f"Set drop_single_idx to True to suppress these errors."
+                )
+                raise PipelineException(msg)
+        else:
+            target_indices.append(target_idx)
+
+    if debug:
+        print(f"Indices converted. {single_idx_count} events of length 0 or 1 dropped.")
+
+    ##
+    ## Interpolate related signal if requested, else return target times.
+    ##
+
+    if return_interpolate:
+
+        ## Create full interpolated signal
+        interpolated_signal = interpolate_signal_data(
+            scan_key, source_type, target_type, source_times, target_times, debug=debug
+        )
+
+        ## Split indices given into fragments based on which ones are continuous (incrementing by 1)
+        source_signal_fragments = []
+        for idx_fragment in target_indices:
+            source_signal_fragments.append(interpolated_signal[idx_fragment])
+
+        ## If full signal is converted, remove wrapping list
+        if len(source_signal_fragments) == 1:
+            source_signal_fragments = source_signal_fragments[0]
+
+        return source_signal_fragments
+
+    else:
+
+        ## Convert indices to times and return
+        source_idx_to_target_times = []
+
+        for target_idx_list in target_indices:
+            source_idx_to_target_times.append(target_times[target_idx_list])
+
+        return source_idx_to_target_times
+
+
+def convert_clocks_time_to_idx(
+    scan_key: dict,
+    time_boundaries,
+    source_type: str,
+    target_type: str,
+    return_interpolate: bool = False,
+    drop_single_idx: bool = True,
+    debug: bool = True,
+):
+    """
+    Converts time boundaries of interest on one type of clock/recording to indices on a target recording
+
+        Parameters:
+
+                scan_key: A dictionary specifying a single scan and/or field. A single field must be defined if requesting
+                          a source or target from ScanImage. If key specifies a single unit, unit delay will be added to
+                          all timepoints recorded. Single units can be specified via unique mask_id + field or via unit_id.
+                          If only field is specified, average field delay will be added.
+
+                time_boundaries: List of lists containing [start,stop] boundaries for times of note on source clock.
+                                 Start/Stop times are included (>=,<=). These boundaries are converted to all indices
+                                 equal to or between recording times on target recording.
+                                 NOTE: Set to None to use the entire source signal length.
+                                 ex. [[271, 314], [690.321, 800.1]] OR None
+
+                source_type: A string specifying what times you want to convert from. Fluorescence and deconvolution
+                             have a dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                target_type: A string specifying what indices to convert into. Fluorescence and deconvolution have a
+                             dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                return_interpolate: Boolean with the following behavior
+                                     - True: Interpolate source signal onto target clock, return interpolated signal
+                                             at indices instead of target indices
+                                             NOTE: NaNs in source signal are linearly interpolated over and then
+                                                   filled back in after interpolation onto target times.
+                                     - False: Return corresponding indices between boundaries for target
+
+                drop_single_idx: Boolean with the following behavior
+                                     - True: Drop any signal fragments which would create a signal of length 1.
+                                     - False: Raise an error and stop if any list of indices leads to a signal
+                                              of length 1.
+                                    ex. Source IDX [1,2,...,300] on a 500HZ recording will only correspond to
+                                        target IDX [1] if target is recorded at 1Hz.
+
+                debug: Set function to print helpful debug text while running
+
+
+        Returns:
+
+                requested_array: Numpy array of corresponding times in target type recording or interpolated
+                                 source signal during target times.
+
+        Warnings:
+
+                * NaN refilling for source signal will only refill values if NaNs stretch for multiple indices on
+                  target clock
+
+                * Recording points where the time value is NaN are dropped from analysis/processing
+    """
+
+    ##
+    ## Fetch source and target times, along with converting between Stimulus or Behavior clock if needed
+    ##
+
+    source_times, target_times = fetch_timing_data(
+        scan_key, source_type, target_type, debug
+    )
+
+    ##
+    ## Check if None is used to set to full length of signal or fix common error of not having a list of lists
+    ##
+
+    if time_boundaries is None:
+        time_start = np.nanmin(source_times)
+        time_stop = np.nanmax(source_times)
+        time_boundaries = [[time_start, time_stop]]
+    elif isinstance(time_boundaries[0], numbers.Number):
+        time_boundaries = [time_boundaries]
+
+    ##
+    ## Convert source indices to time boundaries, then convert time boundaries into target indices
+    ##
+
+    target_indices = []
+    single_idx_count = 0
+
+    ## Loop through start & end times and create list of indices corresponding to that block of time
+    for [start, end] in time_boundaries:
+        target_idx = np.where(
+            np.logical_and(target_times >= start, target_times <= end)
+        )[0]
+        if len(target_idx) < 2:
+            if drop_single_idx:
+                single_idx_count += 1
+            else:
+                msg = (
+                    f"Event of length {len(target_idx)} found. "
+                    f"Set drop_single_idx to True to suppress these errors."
+                )
+                raise PipelineException(msg)
+        else:
+            target_indices.append(target_idx)
+
+    if debug:
+        print(f"Indices converted. {single_idx_count} events of length 0 or 1 dropped.")
+
+    ##
+    ## Interpolate related signal if requested, else just return the target_indices found.
+    ##
+
+    if return_interpolate:
+
+        ## Create full interpolated signal
+        interpolated_signal = interpolate_signal_data(
+            scan_key, source_type, target_type, source_times, target_times, debug=debug
+        )
+
+        ## Split indices given into fragments based on which ones are continuous (incrementing by 1)
+        source_signal_fragments = []
+        for idx_fragment in target_indices:
+            source_signal_fragments.append(interpolated_signal[idx_fragment])
+
+        ## If full signal is converted, remove wrapping list
+        if len(source_signal_fragments) == 1:
+            source_signal_fragments = source_signal_fragments[0]
+
+        return source_signal_fragments
+
+    else:
+
+        return target_indices
+
+
+def convert_clocks_time_to_time(
+    scan_key: dict,
+    time_boundaries,
+    source_type: str,
+    target_type: str,
+    return_interpolate: bool = False,
+    drop_single_idx: bool = True,
+    debug: bool = True,
+):
+    """
+    Converts time boundaries of interest on one type of clock/recording to all times between those boundaries
+    on the target signal/clock
+
+        Parameters:
+
+                scan_key: A dictionary specifying a single scan and/or field. A single field must be defined if requesting
+                          a source or target from ScanImage. If key specifies a single unit, unit delay will be added to
+                          all timepoints recorded. Single units can be specified via unique mask_id + field or via unit_id.
+                          If only field is specified, average field delay will be added.
+
+                time_boundaries: List of lists containing [start,stop] boundaries for times of note on source clock.
+                                 Start/Stop times are included (>=,<=). These boundaries are converted to all indices
+                                 equal to or between recording times on target recording.
+                                 NOTE: Set to None to use the entire source signal length.
+                                 ex. [[271, 314], [690.321, 800.1]] OR None
+
+                source_type: A string specifying what times you want to convert from. Fluorescence and deconvolution
+                             have a dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                target_type: A string specifying what indices to convert into. Fluorescence and deconvolution have a
+                             dash followed by "behavior" or "stimulus" to refer to which clock you are using.
+                             Supported options:
+                                 'fluorescence-stimulus', 'deconvolution-stimulus', ,'fluorescence-behavior',
+                                 'deconvolution-behavior', 'pupil', 'treadmill', 'respiration'
+
+                return_interpolate: Boolean with the following behavior
+                                     - True: Interpolate source signal onto target clock, return interpolated signal
+                                             between time boundaries instead of times
+                                             NOTE: NaNs in source signal are linearly interpolated over and then
+                                                   filled back in after interpolation onto target times.
+                                     - False: Return corresponding times between boundaries for target
+
+                drop_single_idx: Boolean with the following behavior
+                                     - True: Drop any signal fragments which would create a signal of length 1.
+                                     - False: Raise an error and stop if any list of indices leads to a signal
+                                              of length 1.
+                                    ex. Source IDX [1,2,...,300] on a 500HZ recording will only correspond to
+                                        target IDX [1] if target is recorded at 1Hz.
+
+                debug: Set function to print helpful debug text while running
+
+
+        Returns:
+
+                requested_array: Numpy array of corresponding times in target type recording or interpolated
+                                 source signal during target times.
+
+        Warnings:
+
+                * NaN refilling for source signal will only refill values if NaNs stretch for multiple indices on
+                  target clock
+
+                * Recording points where the time value is NaN are dropped from analysis/processing
+    """
+
+    ##
+    ## Fetch source and target times, along with converting between Stimulus or Behavior clock if needed
+    ##
+
+    source_times, target_times = fetch_timing_data(
+        scan_key, source_type, target_type, debug
+    )
+
+    ##
+    ## Check if None is used to set to full length of signal or fix common error of not having a list of lists
+    ##
+
+    if time_boundaries is None:
+        time_start = np.nanmin(source_times)
+        time_stop = np.nanmax(source_times)
+        time_boundaries = [[time_start, time_stop]]
+    elif isinstance(time_boundaries[0], numbers.Number):
+        time_boundaries = [time_boundaries]
+
+    ##
+    ## Convert source indices to time boundaries, then convert time boundaries into target indices
+    ##
+
+    target_indices = []
+    single_idx_count = 0
+
+    ## Loop through start & end times and create list of indices corresponding to that block of time
+    for [start, end] in time_boundaries:
+        target_idx = np.where(
+            np.logical_and(target_times >= start, target_times <= end)
+        )[0]
+        if len(target_idx) < 2:
+            if drop_single_idx:
+                single_idx_count += 1
+            else:
+                msg = (
+                    f"Event of length {len(target_idx)} found. "
+                    f"Set drop_single_idx to True to suppress these errors."
+                )
+                raise PipelineException(msg)
+        else:
+            target_indices.append(target_idx)
+
+    if debug:
+        print(f"Indices converted. {single_idx_count} events of length 0 or 1 dropped.")
+
+    ##
+    ## Interpolate related signal if requested, else return target times.
+    ##
+
+    if return_interpolate:
+
+        ## Create full interpolated signal
+        interpolated_signal = interpolate_signal_data(
+            scan_key, source_type, target_type, source_times, target_times, debug=debug
+        )
+
+        ## Split indices given into fragments based on which ones are continuous (incrementing by 1)
+        source_signal_fragments = []
+        for idx_fragment in target_indices:
+            source_signal_fragments.append(interpolated_signal[idx_fragment])
+
+        ## If full signal is converted, remove wrapping list
+        if len(source_signal_fragments) == 1:
+            source_signal_fragments = source_signal_fragments[0]
+
+        return source_signal_fragments
+
+    else:
+
+        ## Convert indices to times and return
+        source_times_to_target_times = []
+
+        for target_idx_list in target_indices:
+            source_times_to_target_times.append(target_times[target_idx_list])
+
+        return source_times_to_target_times


### PR DESCRIPTION
Three major changes:

1. New file in pipeline.utils called clocktools.py
     - Adds auto-conversion functions between any clocks (behavior, stimulus, odor)
     - Adds auto-interpolation and fetching of signals for nearly all signals of interest (fluorescence, deconvolved activity, respiration, treadmill, pupil)
     - Takes as input indices or time boundaries on any clock

2. New tables to pupil.py
     - ProcessedPupil auto-filters pupil radii
     - Other tables store all detected dilation/constriction events or define methods to do so

3. New tables to treadmill.py
     - Running table detects bouts of running and stores each event
     - RunningMethod stores different methods to detect running like threshold + max gap between the same running bout