### PR TITLE
Add new Running methods and patch clocktools, shared

### DIFF
--- a/python/pipeline/shared.py
+++ b/python/pipeline/shared.py
@@ -205,6 +205,7 @@ class FilterMethod(dj.Lookup):
     contents = [['0.5Hz Hamming Lowpass', 'signal, signal_freq (Hz)', '0.5Hz lowpass filter using hamming window'],
                 ['1Hz Hamming Lowpass', 'signal, signal_freq (Hz)', '1Hz lowpass filter, zero-phase (without added delay) using Hamming window'],
                 ['2Hz Hamming Lowpass', 'signal, signal_freq (Hz)', '2Hz lowpass filter, zero-phase (without added delay) using Hamming window'],
+                ['5Hz Hamming Lowpass', 'signal, signal_freq (Hz)', '5Hz lowpass filter, zero-phase (without added delay) using Hamming window'],
                 ['0.1 - 1Hz Hamming Bandpass', 'signal, signal_freq (Hz)', '0.1 - 1Hz bandpass filter, zero-phase (without added delay) using Hamming window'],
                 ['0.5sec Median Filter', 'signal, signal_freq (Hz)', 'Filter which returns median value over sliding 0.5sec window'],
                 ['NaN Filler', 'signal', 'Linearly interpolates over all NaNs in a signal with NaNs outside of bounds filled via nearest neighbor interpolation'],
@@ -368,6 +369,10 @@ class FilterMethod(dj.Lookup):
         
         elif filter_method == "2Hz Hamming Lowpass":
             kwargs['lowpass_freq'] = 2
+            filtered_signal = FilterMethod._lowpass_hamming(*args, **kwargs)
+        
+        elif filter_method == "5Hz Hamming Lowpass":
+            kwargs['lowpass_freq'] = 5
             filtered_signal = FilterMethod._lowpass_hamming(*args, **kwargs)
         
         elif filter_method == "0.1 - 1Hz Hamming Bandpass":

--- a/python/pipeline/utils/clocktools.py
+++ b/python/pipeline/utils/clocktools.py
@@ -2,12 +2,12 @@ import warnings
 import numpy as np
 import datajoint as dj
 import matplotlib.pyplot as plt
-from stimulus import stimulus
 from scipy import interpolate
 from itertools import groupby
 from pipeline import treadmill, fuse, shared, odor
 from pipeline.exceptions import PipelineException
 
+stimulus = dj.create_virtual_module("stimulus", "pipeline_stimulus")
 pupil = dj.create_virtual_module("pipeline_eye", "pipeline_eye")
 
 


### PR DESCRIPTION
The following changes were made:

1. Adding two new running methods to treadmill which can now pad running periods with a specific amount of time.
     * running_method_id 2 pads with 1sec with a lower threshold of 0.5cm/sec, while running_method_id 3 pads with 10sec with 0.5cm/sec threshold
     * Running periods with padding cannot extend past the first/last recording time for the treadmill trace
2. Clocktools no longer imports stimulus.py and instead creates a virtual module to prevent issues if a collaborator doesn't have the stimuli repository.
3. FilterMethod has new 5Hz lowpass filter.