### PR TITLE
Clocktools sample trace

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,10 +2,9 @@ version: '2.0'
 
 services:
   notebook:
-    image: at-docker.ad.bcm.edu:5000/pipeline:latest 
+    image: ninai/stimulus-pipeline:latest
     ports:
-      - "8887:8888"
-      - "8502:8501"
+      - "8888:8888"
     volumes:
       - /mnt/:/mnt/
       - /home/pipeline_data/:/tmp/
@@ -13,8 +12,13 @@ services:
     env_file: .env
     environment:
       - DISPLAY=$DISPLAY
-    entrypoint: /data/pipeline/entrypoint.sh
-    working_dir: /
+    entrypoint:
+      - jupyter 
+      - lab
+      - --ip=0.0.0.0
+      - --allow-root
+      - --NotebookApp.token=''
+      - --no-browser
 
 
   minion:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,10 @@ version: '2.0'
 
 services:
   notebook:
-    image: ninai/stimulus-pipeline:latest
+    image: at-docker.ad.bcm.edu:5000/pipeline:latest 
     ports:
-      - "8888:8888"
+      - "8887:8888"
+      - "8502:8501"
     volumes:
       - /mnt/:/mnt/
       - /home/pipeline_data/:/tmp/
@@ -12,13 +13,8 @@ services:
     env_file: .env
     environment:
       - DISPLAY=$DISPLAY
-    entrypoint:
-      - jupyter 
-      - lab
-      - --ip=0.0.0.0
-      - --allow-root
-      - --NotebookApp.token=''
-      - --no-browser
+    entrypoint: /data/pipeline/entrypoint.sh
+    working_dir: /
 
 
   minion:


### PR DESCRIPTION
1. Reorganize `fetch_timing_data` into:
    + `scan_image_correction`: fetch delay for the entire field or a single unit based on the argument `scan_key`
    + `fetch_timing_data`: fetch the corresponding timestamps based on the argument `timing_type`
    + `interpolate_timing_data`: interpolates the timestamps from the source timestamps to the target time stamps and vice versa.
2. Add `time-stimulus` as an option in `interpolating_timing_data` to load flip times in stimulus clock. The current implementation concatenates the flip times found in `stimulus.Trial`, which is not necessary since concatenated flip times already exist in `stimulus.Sync.Syncmodel`. However `Syncmodel` tables are not populated for the platinum scans yet. The current implementation should be updated after the `Syncmodel` tables are repopulated for the platinum scans.
3. Implement `sample_trace` using `fetch_timing_data`, `interpolate_timing_data` and `interpolating_signal_data` to sample the traces at arbitrary time points in stimulus time. This function could be extended to sample with behavior time as well, not implemented at the moment.