### PR TITLE
Fix clocktools import to prevent extra dependencies

### DIFF
--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -32,7 +32,6 @@ import datajoint as dj
 from datajoint.jobs import key_hash
 from datajoint.autopopulate import AutoPopulate
 
-from .utils import clocktools
 from .utils.decorators import gitlog
 from .utils import eye_tracking, h5
 from .utils.eye_tracking import PupilTracker, ManualTracker
@@ -1184,6 +1183,9 @@ class ProcessedPupil(dj.Computed):
         return deeplabcut_fitting * PupilFilterMethod
     
     def _make_tuples(self, key):
+              
+       ## Import clocktools here to prevent dependency on stimulus.py for non-stimulus Docker containers
+       from .utils import clocktools
 
         print(f'Generating ProcessedPupil for {key}')
         

--- a/python/pipeline/treadmill.py
+++ b/python/pipeline/treadmill.py
@@ -7,7 +7,7 @@ from pipeline import shared
 import os
 
 from . import experiment, notify
-from .utils import h5, clocktools
+from .utils import h5
 from .exceptions import PipelineException
 
 
@@ -222,7 +222,9 @@ class Running(dj.Computed):
                 combined_running_fragments: List of lists of continuous incrementing indices corresponding to
                                             single periods of running.
         """
-
+        ## Import clocktools here to prevent dependency on stimulus for non-stimulus containers just importing treadmill
+        from .utils import clocktools
+        
         ## Splits list of indices into a list of lists. Each sublist contains indices which continuously increase by 1.
         ## This function also drops sublists which only contain a single idx.
         running_fragments = clocktools.find_idx_boundaries(running_indices, drop_single_idx=True)


### PR DESCRIPTION
Clocktools was previously imported in the beginning of treadmill.py and pupil.py. However, clocktools requires stimulus.py, adding an unnecessary dependency for everything. The import was moved to the specific functions which require it.