### PR TITLE
Adding odor.StackMatching and registration.py bugfix

### DIFF
--- a/python/pipeline/utils/registration.py
+++ b/python/pipeline/utils/registration.py
@@ -78,7 +78,7 @@ def affine_product(X, A, b):
 
     :return: A (d1 x d2 x 3) torch.Tensor corresponding to the transformed coordinates.
     """
-    return torch.einsum('ij,klj->kli', (A, X)) + b
+    return torch.einsum('ij,klj->kli', (A.float(), X.float())) + b
 
 
 def sample_grid(volume, grid):

--- a/python/pipeline/utils/registration.py
+++ b/python/pipeline/utils/registration.py
@@ -78,7 +78,7 @@ def affine_product(X, A, b):
 
     :return: A (d1 x d2 x 3) torch.Tensor corresponding to the transformed coordinates.
     """
-    return torch.einsum('ij,klj->kli', (A.float(), X.float())) + b
+    return torch.einsum('ij,klj->kli', (A.double(), X.double())) + b
 
 
 def sample_grid(volume, grid):


### PR DESCRIPTION
StackMatching Update
* odor.StackMatching is a copy of stack.StackSet modified to only run on odor.MesoMatch scans with glomeruli

Registration Bug FIx
* stack.StackSet relies on registration.py's affine_product() function
* affine_product takes three tensors which are not checked for dtype and can fail if one tensor's dtype is float64 instead of float32
* This has been fixed by casting all tensors to dtype float64 before calculating the affine product