### PR TITLE
Update h5.py

### DIFF
--- a/python/pipeline/utils/h5.py
+++ b/python/pipeline/utils/h5.py
@@ -78,6 +78,13 @@ def read_behavior_file(filename):
             analog_signals = np.array(f['Analog Signals'])
             channel_names = f.attrs['AS_channelNames'].decode('ascii').split(',')
             channel_names = [cn.strip() for cn in channel_names]
+            
+            for i,channel_name in enumerate(channel_names): # only works up to 9 channels
+                if ':' in channel_name:
+                    colon_index = channel_name.find(':')        
+                    expanded_indices = np.arange(int(channel_name[colon_index-1]),int(channel_name[colon_index+1])+1)
+                    expanded_channel_names = [channel_name[:colon_index-1] + str(ex_i) for ex_i in expanded_indices]
+                    channel_names[i:i+1] = expanded_channel_names
             data['syncPd'] = analog_signals[channel_names.index('Photodiode')]
             data['ts'] = analog_signals[channel_names.index('Time')]
             if 'Temperature' in channel_names:


### PR DESCRIPTION
THIS IS A HOTFIX THAT SHOULD BE REPLACED

h5 util previously failed to update channel indices where channels were grouped under 1:x notation for x channels of the same type -- added string comprehension loop to replace that with multiple channel names so indexing could proceed normally. 