### PR TITLE
Added support for new MotionCorrection methods

### DIFF
--- a/python/pipeline/shared.py
+++ b/python/pipeline/shared.py
@@ -197,7 +197,8 @@ class MotionCorrectionMethod(dj.Lookup):
     correction_method_details   : varchar(1024)
     """
     contents = [
-        [1, "Default motion correction"],
+        [0, "Legacy motion correction (before 2023). Code has been replaced."],
+        [1, "Default motion correction meant to replicate legacy code"],
         [2, "Motion correction with global template and 10um movement limit"],
         [3, "Motion correction with global template, 10um movement limit, and 0.5um shift maximum for 30Hz"],
         [4, "Motion correction with global template, 10um movement limit, 0.33sec rolling mean, and 0.5um shift maximum for 30Hz"],

--- a/python/pipeline/shared.py
+++ b/python/pipeline/shared.py
@@ -188,6 +188,26 @@ class SurfaceMethod(dj.Lookup):
         [1, 'Paraboloid Fit', 'Fit ax^2 + by^2 + cx + dy + f to surface after finding max of sobel']
     ]
 
+
+@schema
+class MotionCorrectionMethod(dj.Lookup):
+    definition = """ # methods for motion correction
+    motion_correction_method    : tinyint unsigned
+    ---
+    correction_method_details   : varchar(1024)
+    """
+    contents = [
+        [1, "Default motion correction"],
+        [2, "Motion correction with global template and 10um movement limit"],
+        [3, "Motion correction with global template, 10um movement limit, and 0.5um shift maximum for 30Hz"],
+        [4, "Motion correction with global template, 10um movement limit, 0.33sec rolling mean, and 0.5um shift maximum for 30Hz"],
+        [5, "Method 4 with second iteration of global template on scan with 3 frame rolling mean applied."],
+        [6, "Method 4 with second iteration of 2000 frame local templates with 500 frame overlap on scan with 3 frame rolling mean applied."],
+        [7, "Method 4 with second iteration of global template on scan with 0.2s frame rolling mean applied."],
+        [8, "Method 4 with second iteration of 2000 frame local templates with 500 frame overlap on scan with 0.2s frame rolling mean applied."],
+    ]
+
+
 @schema
 class ExpressionConstruct(dj.Lookup):
     definition = """ # Construct expressed within certain fields

--- a/python/pipeline/utils/performance.py
+++ b/python/pipeline/utils/performance.py
@@ -53,7 +53,10 @@ def map_frames(f, scan, field_id, channel, y=slice(None), x=slice(None), kwargs=
         pool.append(p)
 
     # Produce data
-    num_frames = scan.num_frames
+    if isinstance(scan, np.ndarray):
+        num_frames = scan.shape[-1]
+    else:
+        num_frames = scan.num_frames
     for i in range(0, num_frames, chunk_size):
         frames = slice(i, min(i + chunk_size, num_frames))
         chunks.put((frames, scan[field_id, y, x, channel, frames])) # frames, chunk tuples


### PR DESCRIPTION
Added new motion correction methods and modifications to supporting tables/code.

The structure is as follows:

shared.MotionCorrectionMethod + meso.MotionMethodForScan -> meso.MotionCorrection -> meso.MotionCorrection.MotionMethodUsed

Method 8 is currently suggested as the best method and is automatically filled out in MotionMethodForScan once RasterCorrection is done populating. This ensures users do not need to perform extra steps to process their scans. The method used is also recorded in a new part table, MotionMethodUsed. This is done because MotionCorrection cannot have MotionMethodForScan added as a dependency without recreating the table, so keys in MotionMethodForScan could be changed/deleted without it propagating downstream.