### PR TITLE
fix: prevent overwriting function names in _get_correct_raster

### DIFF
--- a/python/pipeline/utils/galvo_corrections.py
+++ b/python/pipeline/utils/galvo_corrections.py
@@ -371,12 +371,10 @@ def _get_correct_raster(key):
     raster_phase = (pipe.RasterCorrection & key).fetch1("raster_phase")
     fill_fraction = (pipe.ScanInfo & key).fetch1("fill_fraction")
     if abs(raster_phase) < 1e-7:
-        correct_raster = lambda scan: scan.astype(np.float32, copy=False)
-    else:
-        correct_raster = lambda scan: correct_raster(
-            scan, raster_phase, fill_fraction
-        )
-    return correct_raster
+        return lambda scan: scan.astype(np.float32, copy=False)
+    return lambda scan: correct_raster(
+        scan, raster_phase, fill_fraction
+    )
     
 
 def low_memory_motion_correction(scan, raster_phase, fill_fraction, x_shifts, y_shifts):


### PR DESCRIPTION
The original code overwrites `correct_raster` defined earlier and will throw "TypeError: <lambda>() takes 1 positional argument but 3 were given" for every scan that has a non-zero raster_phase.