### PR TITLE
implement CronJob for populate stack.RegistrationOverTime

### DIFF
--- a/K8/CronJobs/minion-reg-over-time.yaml
+++ b/K8/CronJobs/minion-reg-over-time.yaml
@@ -1,0 +1,87 @@
+apiVersion: batch/v1beta1
+kind: CronJob # This tells kubernetes what kind of class it is working with
+metadata:
+  name: minion
+spec:
+  schedule: "*/5 * * * *" # every 5 minutes
+  concurrencyPolicy: Allow
+  failedJobsHistoryLimit: 30
+  successfulJobsHistoryLimit: 30
+  jobTemplate:
+    spec:
+      parallelism: 1  # how many process in parallel I want
+      template:
+        spec:
+          restartPolicy: Never
+          hostNetwork: true # This option will allow the pod to use the host network for internet access
+          volumes:
+          - name: mnt
+            hostPath:
+              path: /mnt
+          affinity: # Affinity to select certain nodes with 11GB, 12GB, or 24GB memory
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution: # Require nodes to have this label
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: kubernetes.io/hostname # Target label is gpu_mem_size
+                    operator: In # Key must have one of the following values
+                    values:
+                    - at-compute003
+                    - at-compute004
+                    - at-compute005
+                    - at-compute006
+                    - at-compute007
+                    - at-compute008
+                    - at-compute009
+                    - at-compute010
+                    - at-compute011
+                    - at-compute012
+                    - at-compute013
+                    - at-compute014    
+          priorityClassName: medium-priority
+          containers:
+          - name: minion
+            image: at-docker.ad.bcm.edu:5000/pipeline:latest
+            volumeMounts:
+            - name: mnt
+              mountPath: /mnt
+            resources:
+              requests:
+                cpu: 1
+                memory: 32Gi
+                ephemeral-storage: 50Gi
+            env:
+            - name: DJ_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: datajoint-credentials
+                  key: DJ_HOST
+            - name: DJ_USER
+              valueFrom:
+                secretKeyRef:
+                  name: datajoint-credentials
+                  key: DJ_USER
+            - name: DJ_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: datajoint-credentials
+                  key: DJ_PASS
+            - name: GITHUB_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: github-credentials
+                  key: GITHUB_USERNAME
+            - name: GITHUB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: github-credentials
+                  key: GITHUB_PASSWORD
+            command: ["/bin/bash"]
+            args: ["-c", "rm -r pipeline &&\
+            git clone https://$(GITHUB_USERNAME):$(GITHUB_PASSWORD)@github.com/cajal/pipeline.git &&\
+            pip3 install pipeline/python/ &&\
+            git clone https://$(GITHUB_USERNAME):$(GITHUB_PASSWORD)@github.com/cajal/stimulus-pipeline.git &&\
+            pip3 install stimulus-pipeline/python/ &&\
+            git clone https://$(GITHUB_USERNAME):$(GITHUB_PASSWORD)@github.com/cajal/stimuli.git &&\
+            pip3 install stimuli/python/ &&\
+            python3 /data/pipeline/python/scripts/populate-reg-over-time.py"]

--- a/python/pipeline/stack.py
+++ b/python/pipeline/stack.py
@@ -2066,6 +2066,14 @@ class FieldSegmentation(dj.Computed):
                                     'mask_y': mask_y, 'mask_x': mask_x,
                                     'distance': distance})
 
+@schema
+class RegistrationOverTimeTask(dj.Manual):
+    definition = """ # scans that will be candidates for stack.RegistrationOverTime
+    -> PreprocessedStack.proj(stack_session='session', stack_channel='channel')
+    -> RegistrationTask
+    ---
+    zdrift_query_ts=CURRENT_TIMESTAMP : timestamp
+    """
 
 @schema
 class RegistrationOverTime(dj.Computed):
@@ -2076,8 +2084,7 @@ class RegistrationOverTime(dj.Computed):
     """
     @property
     def key_source(self):
-        stacks = PreprocessedStack.proj(stack_session='session', stack_channel='channel')
-        return stacks * RegistrationTask & {'registration_method': 5}
+        return RegistrationOverTimeTask & (meso.SummaryImages + reso.SummaryImages).proj(scan_session='session')
 
     class Chunk(dj.Part):
         definition = """ # single registered chunk

--- a/python/scripts/populate-reg-over-time.py
+++ b/python/scripts/populate-reg-over-time.py
@@ -1,0 +1,29 @@
+#!/usr/local/bin/python3
+
+'''
+For populating RegistrationOverTime
+Prerequisite: 
+    - insert scans and stacks to RegistrationTask
+    - run populate-minion.py (this is usually run by the pipeline minion automatically)
+    - insert scans and stacks of interest into stack.ZDriftQuery
+'''
+
+from pipeline import stack
+import logging
+import datajoint as dj
+
+## database logging code 
+
+logging.basicConfig(level=logging.ERROR)
+logging.getLogger('datajoint.connection').setLevel(logging.DEBUG)
+if hasattr(dj.connection, 'query_log_max_length'):
+    dj.connection.query_log_max_length = 3000 
+
+# delete errors
+err_msg_timeout = 'error_message = "InternalError: (1205, \'Lock wait timeout exceeded; try restarting transaction\')"'
+err_msg_sigterm = 'error_message = "SystemExit: SIGTERM received"'
+timestamp = 'timestamp > "2021-12-10"'
+(stack.schema.jobs & [err_msg_timeout, err_msg_sigterm] & timestamp).delete()
+
+# populate RegistrationOverTime
+stack.RegistrationOverTime.populate(reserve_jobs=True, suppress_errors=True)


### PR DESCRIPTION
This PR implements CronJob `minion-reg-over-time` for populating table `stack.RegistrationOverTime`.

`minion-reg-over-time` will be deployed every 5 mins with `median-priority`.

To populate `stack.RegistrationOverTime` for a certain scan, the experimenter first inserts the scan and stack of interest into the newly implemented table `stack.RegistrationOverTimeTask`. The minion will pick up any scan inserted and start populating the `stack.RegistrationOverTime` table accordingly.