### PR TITLE
add separate deeplabcut model for neuropixel recordings

### DIFF
--- a/python/pipeline/pupil.py
+++ b/python/pipeline/pupil.py
@@ -729,11 +729,17 @@ class Tracking(dj.Computed):
             """
 
             print('Tracking labels with Deeplabcut!')
+            # get which rig the experiment was performed on
+            rig = (experiment.Session & key).fetch1('rig')
 
-            # change config_path if we were to update DLC model configuration
-            temp_config = (ConfigDeeplabcut & dict(
-                config_path='/mnt/lab/DeepLabCut/pupil_track-Donnie-2019-02-12/config.yaml')).fetch1()
-
+            if rig in ['RS1',]:
+                # in some rigs, there is no internal illumination from infrared leakage from two photon excitation
+                # i.e., pupil is black on gray background, and a separate dlc model is required
+                temp_config = (ConfigDeeplabcut & dict(config_path='/mnt/lab/DeepLabCut/pupil_track-Maria-Alex-2023-05-15/config.yaml')).fetch1()
+            else:
+                # assume all other rigs have two photon leakage (default dlc model) until new exception emerges
+                temp_config = (ConfigDeeplabcut & dict(config_path='/mnt/lab/DeepLabCut/pupil_track-Donnie-2019-02-12/config.yaml')).fetch1()
+                
             # save config_path into the key
             key['config_path'] = temp_config['config_path']
 


### PR DESCRIPTION
At some rigs (e.g. neuropixel recording rigs), there is no internal illumination from two-photon excitation, i.e., the pupil is black on gray background, thus a separate DeepLabCut model is required. 

This PR introduces a DeepLabCut model Alex and Maria helped train on neuropixel recordings. This model was able to reliably track the pupil in most scenarios as shown in the example recording session below. In the examples, the tracking and fitting results are shown below the raw frames. Red dots are tracking points and the yellow circle is the fitting result, the yellow circle will be absent if the tracking results do not pass a confidence threshold. 

# Examples
## `'animal_id': 29189, 'session':16, 'scan_idx': 1`
This recording includes a wide range of pupil sizes, and the model reliably tracks the pupil's location and size.
![image](https://github.com/cajal/pipeline/assets/35954094/f78a7d9a-1049-4703-8728-78f1adf337f5)

## `'animal_id': 29189, 'session':33, 'scan_idx': 1`
This recording includes a few examples where the pupil was obscured by the eyelid. The mode marked those frames as NaNs (yellow circle absent) as expected.
![image](https://github.com/cajal/pipeline/assets/35954094/0e3fc5e1-145d-4477-8b14-914417c3ca1c)

## `'animal_id': 29187, 'session':24, 'scan_idx': 1`
The pupil quality of this recording is suboptimal, there are multiple occasions where the pupil is not visible in the frame. The model marks most of those frames as NaNs as expected.
![image](https://github.com/cajal/pipeline/assets/35954094/f6e5d125-29c9-4dd4-8242-488d65073f30)

## `'animal_id': 29767, 'session':1, 'scan_idx': 1`
The mouse is very tired in this recording session. The eye is half-close most of the time. In those occasions, the model estimates the pupil size. We have seen similar issues for two-photon imaging pupil tracking but those scans were usually discarded regardless since it is hard to tell if the mouse was seeing the entire monitor when its eye is half-close.
![image](https://github.com/cajal/pipeline/assets/35954094/8ec9881e-4054-4cc9-9078-f2fd45439664)
