### PR TITLE
Add Vizari LBM machine to rig whitelist in meso.scanInfo.key_source()

### DIFF
--- a/python/pipeline/meso.py
+++ b/python/pipeline/meso.py
@@ -54,7 +54,7 @@ class ScanInfo(dj.Imported):
 
     @property
     def key_source(self):
-        rigs = [{"rig": "2P4"}, {"rig": "R2P1"}]
+        rigs = [{"rig": "2P4"}, {"rig": "R2P1"}, {"rig": "V2P1"}]
         meso_scans = experiment.Scan() & (experiment.Session() & rigs)
         return meso_scans * (Version() & {"pipe_version": CURRENT_VERSION})
 


### PR DESCRIPTION
The key_source function for meso.ScanInfo() is limited to only include two rigs: "2P4" and "R2P1". However, in order to run the LBM scans through the pipeline, we need to include a third rig: "V2P1" which corresponds to the Vizari Lab's LBM rig at Rockefeller where these initial LBM scans took place.

I have confirmed that this change will include Vizari LBM scans in meso.ScanInfo.key_source() by running an extracted key_source function in a notebook.