### PR TITLE
Update shared.py to handle the amount of fields for lbm scans

### DIFF
--- a/python/pipeline/shared.py
+++ b/python/pipeline/shared.py
@@ -10,9 +10,9 @@ schema = dj.schema('pipeline_shared', locals(), create_tables=False)
 @schema
 class Field(dj.Lookup):
     definition = """ # fields in mesoscope scans
-    field       : tinyint
+    field       : smallint
     """
-    contents = [[i] for i in range(1, 25)]
+    contents = [[i] for i in range(1, 150)]
 
 @schema
 class Channel(dj.Lookup):


### PR DESCRIPTION
Currently, shared.Field() is created with 25 fields. This is not sufficient to handle the expected range of fields per scan for LBM scans. Current expected range is 120-150 fields, although 150 is not a hard limit.

Additionally, the datatype used in this table should be changed from tinyint to smallint, as tinyint only has a range of (-128 to 127). smallint has a more-than-sufficient range of (-32,768 to 32,767).

This table will likely not be re-created prior to the development of a/the new pipeline. I'm making this PR to remind those in the future to consider this when making design choices for that new pipeline. Feel free to leave this PR un-approved until that time.
