### PR TITLE
feat: add spike_method: 6 to reso

### DIFF
--- a/python/pipeline/reso.py
+++ b/python/pipeline/reso.py
@@ -1872,6 +1872,26 @@ class Activity(dj.Computed):
                 Activity.Trace().insert1({**key, 'unit_id': unit_id, 'trace': spike_trace})
                 Activity.ARCoefficients().insert1({**key, 'unit_id': unit_id, 'g': ar_coeffs},
                                                   ignore_extra_fields=True)
+                
+        elif key["spike_method"] == 6:  # dnmf
+            from pipeline.utils import caiman_interface as cmn
+            import multiprocessing as mp
+            from functools import partial
+
+            scan_fps = (ScanInfo & key).fetch1('fps')
+            deconvolve = partial(cmn.deconvolve_detrended, scan_fps=scan_fps)
+            with mp.Pool(10) as pool:
+                results = pool.map(deconvolve, full_traces)
+            for unit_id, (spike_trace, ar_coeffs) in zip(unit_ids, results):
+                spike_trace = spike_trace.astype(np.float32, copy=False)
+                Activity.Trace().insert1(
+                    {**key, "unit_id": unit_id, "trace": spike_trace}
+                )
+                Activity.ARCoefficients().insert1(
+                    {**key, "unit_id": unit_id, "g": ar_coeffs},
+                    ignore_extra_fields=True,
+                )
+        
         else:
             msg = 'Unrecognized spike method {}'.format(key['spike_method'])
             raise PipelineException(msg)


### PR DESCRIPTION
# Summary
Adds spike method 6 to pipeline/reso.py, ported from pipeline/meso.py.

# What changes

Method 6 uses CaImAn’s cmn.deconvolve_detrended, which detrends fluorescence traces prior to deconvolution.

The previous reso method (method 5) uses cmn.deconvolve (no detrending).

# Implementation notes

cmn.deconvolve_detrended requires the scan frame rate (fps). We fetch it from ScanInfo and bind it via functools.partial:

scan_fps = (ScanInfo & key).fetch1('fps')
deconvolve = partial(cmn.deconvolve_detrended, scan_fps=scan_fps)

The resulting deconvolve callable replaces the cmn.deconvolve used in method 5; all downstream steps are unchanged.

# Compatibility

No new dependencies on meso; the implementation is self-contained and fully compatible with the reso pipeline.

Method 5 remains available; this PR only adds method 6.

# Rationale

Using detrended deconvolution can reduce baseline drift effects before spike inference, improving robustness on slowly varying signals.